### PR TITLE
[feature] CalendarView 와 Calendar 컴포넌트 기본 마크업 구조 작성

### DIFF
--- a/client/src/Components/Calendar/index.ts
+++ b/client/src/Components/Calendar/index.ts
@@ -1,0 +1,72 @@
+import Component from '@/Core/Component';
+import './styles';
+import { html } from '@/utils/helper';
+
+export default class Calendar extends Component {
+  template() {
+    return html`
+      <table class="calendar-table">
+        <tbody>
+          <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>1</td>
+            <td>
+              <div class="history">
+                <div class="income">${'1,450,000'}</div>
+                <div class="outcome">${'-50,000'}</div>
+                <div class="amount">${'1,400,000'}</div>
+              </div>
+              <div class="day">2</div>
+            </td>
+            <td>3</td>
+          </tr>
+
+          <tr>
+            <td>4</td>
+            <td>5</td>
+            <td>6</td>
+            <td>7</td>
+            <td>8</td>
+            <td>9</td>
+            <td>10</td>
+          </tr>
+
+          <tr>
+            <td>11</td>
+            <td>12</td>
+            <td>13</td>
+            <td>14</td>
+            <td>15</td>
+            <td>16</td>
+            <td>17</td>
+          </tr>
+
+          <tr>
+            <td>18</td>
+            <td>19</td>
+            <td>20</td>
+            <td>21</td>
+            <td>22</td>
+            <td>23</td>
+            <td>24</td>
+          </tr>
+
+          <tr>
+            <td>25</td>
+            <td>26</td>
+            <td>27</td>
+            <td class="${'today'}">28</td>
+            <td>29</td>
+            <td>30</td>
+            <td>31</td>
+          </tr>
+        </tbody>
+
+        <tbody></tbody>
+      </table>
+    `;
+  }
+}

--- a/client/src/Components/Calendar/styles.scss
+++ b/client/src/Components/Calendar/styles.scss
@@ -1,0 +1,61 @@
+@import '@/scss/theme';
+
+.calendar-table {
+  width: 100%;
+  background-color: $off-white;
+  border: 1px solid $line;
+  border-collapse: unset;
+  border-radius: 1rem;
+  box-shadow: 0 0.4rem 0.4rem rgba(0, 0, 0, 0.1),
+    0 0.4rem 2rem rgba(0, 0, 0, 0.1);
+
+  tr {
+    height: 12rem;
+    display: flex;
+
+    td {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      padding: 1rem;
+      box-sizing: border-box;
+      @include bold-small;
+      color: $label;
+
+      .history {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        @include bold-medium;
+
+        .income {
+          color: $primary3;
+        }
+        .outcome {
+          color: $red;
+        }
+        .amount {
+          color: $title-active;
+        }
+      }
+
+      .day {
+        display: flex;
+        align-items: flex-end;
+        justify-content: flex-end;
+      }
+
+      &.today {
+        background-color: $backgrond;
+      }
+    }
+
+    td + td {
+      border-left: 1px solid $line;
+    }
+  }
+
+  tr + tr {
+    border-top: 1px solid $line;
+  }
+}

--- a/client/src/Components/Header/index.ts
+++ b/client/src/Components/Header/index.ts
@@ -7,7 +7,7 @@ import { svgIcons } from '@/assets/svgIcons';
 export default class Header extends Component {
   template() {
     return html`
-      <div class="header-wrapper">
+      <div class="header-wrapper container">
         <span class="header-title">우아한 가계부</span>
         <div class="switch">
           <div class="switch btn" id="btn-prev-month">${svgIcons.leftBtn}</div>

--- a/client/src/View/Calendar/index.ts
+++ b/client/src/View/Calendar/index.ts
@@ -1,8 +1,0 @@
-import Component from '@/Core/Component';
-import { html } from '@/utils/helper';
-
-export default class Calendar extends Component {
-  template() {
-    return html`<div>e달력</div>`;
-  }
-}

--- a/client/src/View/CalendarView/index.ts
+++ b/client/src/View/CalendarView/index.ts
@@ -1,0 +1,39 @@
+import './styles';
+import Component from '@/Core/Component';
+import { html } from '@/utils/helper';
+import Calendar from '@/Components/Calendar';
+
+export default class CalendarView extends Component {
+  template() {
+    return html`
+      <section class="calendar-wrapper container">
+        <ul class="weeks-bar">
+          <li>일</li>
+          <li>월</li>
+          <li>화</li>
+          <li>수</li>
+          <li>목</li>
+          <li>금</li>
+          <li>토</li>
+        </ul>
+
+        <div class="calendar"></div>
+
+        <div class="price-bar">
+          <div class="in-outcome">
+            <span class="price-content">총 수입 ${'1,450,000'}</span>
+            <span class="price-content">총 지출 ${'50,000'}</span>
+          </div>
+          <div class="total">
+            <span class="price-content">총계 ${'1,400,000'}</span>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  mounted() {
+    const $calendar = this.$target.querySelector('.calendar') as HTMLElement;
+    new Calendar($calendar);
+  }
+}

--- a/client/src/View/CalendarView/styles.scss
+++ b/client/src/View/CalendarView/styles.scss
@@ -1,0 +1,42 @@
+@import '@/scss/theme';
+
+.calendar-wrapper {
+  position: relative;
+
+  .weeks-bar {
+    position: absolute;
+    top: -2.5rem;
+    display: flex;
+    width: 100%;
+    height: 4.8rem;
+    align-items: center;
+    box-shadow: 0 0.4rem 0.4rem rgba(0, 0, 0, 0.1),
+      0 0.4rem 2rem rgba(0, 0, 0, 0.1);
+    border-radius: 1rem;
+    background-color: $off-white;
+
+    li {
+      flex: 1;
+      text-align: center;
+      @include body-regular;
+      color: $label;
+    }
+  }
+
+  .calendar {
+    padding-top: 5rem;
+  }
+
+  .price-bar {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 4rem;
+    @include bold-medium;
+    color: $grey1;
+
+    .in-outcome {
+      display: flex;
+      gap: 2rem;
+    }
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -3,7 +3,7 @@ import { initRouter, Route } from '@/Core/Router';
 import Home from '@/View/Home/index';
 import Header from '@/Components/Header';
 import Main from '@/View/Main';
-import Calendar from '@/View/Calendar/index';
+import CalendarView from '@/View/CalendarView';
 import Charts from '@/View/Charts/index';
 
 const $app = document.querySelector('.content-wrapper') as HTMLElement;
@@ -12,7 +12,7 @@ const routes: Route[] = [
   { path: '/', redirect: '/home' },
   { path: '/home', component: Home },
   { path: '/main', component: Main },
-  { path: '/calendar', component: Calendar },
+  { path: '/calendar', component: CalendarView },
   { path: '/charts', component: Charts },
 ];
 

--- a/client/src/scss/index.scss
+++ b/client/src/scss/index.scss
@@ -20,3 +20,7 @@ html {
 svg {
   stroke: $btn-deactive;
 }
+
+.container {
+  max-width: 102.4rem; // 1024px
+}

--- a/client/src/scss/index.scss
+++ b/client/src/scss/index.scss
@@ -23,4 +23,5 @@ svg {
 
 .container {
   max-width: 102.4rem; // 1024px
+  margin: auto;
 }

--- a/client/src/scss/theme.scss
+++ b/client/src/scss/theme.scss
@@ -12,6 +12,8 @@ $primary2: #a0e1e0;
 $primary3: #219a95;
 $error: #f45452;
 $cancel: #f45452;
+$red: #f45452;
+$grey1: #888888;
 
 // category colors
 $category1: #6ed5eb;


### PR DESCRIPTION
### Commit

- Calendar 컴포넌트  마크업 작성 : 하드코딩으로 작성되어 있어 추후 반복문을 통해 출력하도록 변경 필요
- 기획서 디자인에 일부 없는 색상들 추가
- CalendarView 기본 마크업 구조 작성
- `.container` 클래스를 상단에 선언하여 기본 해상도로 사용

### Proposal

- 컴포넌트와 뷰의 이름이 겹쳐 뷰는 ...View로 통일하는 것이 좋을 거 같습니다.
- '.container` 클래스와 같이 동일한 클래스 명을 상단부에 적용하여 동일 해상도를 적용하면 좋을 거 같아요~