### PR TITLE
[refactor] observer 패턴 구조에서 발생하는 리-렌더링 중복 문제 해결

### DIFF
--- a/client/src/Components/Calendar/index.ts
+++ b/client/src/Components/Calendar/index.ts
@@ -1,6 +1,6 @@
 import Component from '@/Core/Component';
 import './styles';
-import { html, addComma } from '@/utils/helper';
+import { html, addComma, asyncSetState } from '@/utils/helper';
 import {
   Props,
   TodayModelType,
@@ -48,15 +48,15 @@ export default class Calendar extends Component<CalendarState, Props> {
       today: this.todayModel.today,
       historyCards: this.mainModel.historyCards,
       historyType: this.mainModel.historyType,
-      histories: {},
     };
 
-    this.mainModel.getHistoryCard(this.$state!.today);
+    asyncSetState(this.mainModel.getHistoryCard(this.$state!.today));
 
     console.log(this.$state);
   }
 
   template() {
+    console.log('아마 2번일걸?');
     return html`
       <table class="calendar-table">
         <tbody class="calendar-tbody"></tbody>
@@ -72,7 +72,8 @@ export default class Calendar extends Component<CalendarState, Props> {
    * }
    */
   filterHistories() {
-    const { historyCards, histories } = this.$state!;
+    const histories: { [key: string]: HistoryTypeForDate } = {};
+    const { historyCards } = this.$state!;
     historyCards?.forEach((history) => {
       const { date, type, price } = history;
       const { income, outcome, amount } = histories?.[date]?.history ?? {
@@ -99,6 +100,8 @@ export default class Calendar extends Component<CalendarState, Props> {
         };
       }
     });
+
+    return histories;
   }
 
   getTodayDates() {
@@ -139,7 +142,7 @@ export default class Calendar extends Component<CalendarState, Props> {
 
   // 데이터 연동이 되는 시점에서 내부 로직을 조금 분리할 계획입니다..!
   makeCalendar(today_date: number, last_date: number, first_day: number) {
-    this.filterHistories();
+    const histories = this.filterHistories();
     const { year, month } = this.$state!.today;
     const $calendar = this.$target.querySelector(
       '.calendar-tbody'
@@ -165,7 +168,7 @@ export default class Calendar extends Component<CalendarState, Props> {
           $cell.classList.add('today');
         $cell.innerHTML = this.makeHistoryForDate({
           date: i,
-          history: this.$state?.histories[date]?.history ?? { amount: null },
+          history: histories[date]?.history ?? { amount: null },
         });
         first_day++;
       } else {
@@ -177,7 +180,7 @@ export default class Calendar extends Component<CalendarState, Props> {
         // 더미데이터 : 추후 삭제 예정
         $cell.innerHTML = this.makeHistoryForDate({
           date: i,
-          history: this.$state?.histories[date]?.history ?? { amount: null },
+          history: histories[date]?.history ?? { amount: null },
         });
         first_day -= SIX_DAYS;
       }

--- a/client/src/Components/Header/index.ts
+++ b/client/src/Components/Header/index.ts
@@ -13,6 +13,7 @@ export default class Header extends Component<DateState, Props> {
   mainModel!: MainModelType;
 
   setup() {
+    this.classIDF = 'Header';
     // main 모델(history) 구독
     this.mainModel = MainModel;
     this.mainModel.subscribe(this.mainModel.key, this);
@@ -26,7 +27,7 @@ export default class Header extends Component<DateState, Props> {
   }
 
   template() {
-    console.log(this.$state);
+    console.log('date : ', this.$state?.today);
     const { year, month } = this.$state!.today;
 
     return html`

--- a/client/src/Components/Header/index.ts
+++ b/client/src/Components/Header/index.ts
@@ -1,6 +1,6 @@
 import './styles';
 import Component from '@/Core/Component';
-import { html } from '@/utils/helper';
+import { asyncSetState, html } from '@/utils/helper';
 import { $router } from '@/Core/Router';
 import { svgIcons } from '@/assets/svgIcons';
 import { MainModelType, Props, TodayModelType } from '@/utils/types';
@@ -26,6 +26,7 @@ export default class Header extends Component<DateState, Props> {
   }
 
   template() {
+    console.log(this.$state);
     const { year, month } = this.$state!.today;
 
     return html`
@@ -71,13 +72,17 @@ export default class Header extends Component<DateState, Props> {
   }
 
   handleClickPrevBtn() {
-    this.model.getPrevDate();
-    this.mainModel.getHistoryCard(this.$state!.today);
+    asyncSetState(
+      this.model.getPrevDate(),
+      this.mainModel.getHistoryCard(this.model.today)
+    );
   }
 
   handleClickNextBtn() {
-    this.model.getNextData();
-    this.mainModel.getHistoryCard(this.$state!.today);
+    asyncSetState(
+      this.model.getNextData(),
+      this.mainModel.getHistoryCard(this.model.today)
+    );
   }
 
   setEvent() {

--- a/client/src/Components/Main/index.ts
+++ b/client/src/Components/Main/index.ts
@@ -8,7 +8,7 @@ import {
   TodayModelType,
   HistoryType,
 } from '@/utils/types';
-import { addComma, html } from '@/utils/helper';
+import { addComma, asyncSetState, html } from '@/utils/helper';
 import MainModel from '@/Model/MainModel';
 import HistoryDayCard from '../HistoryDayCard';
 import { IHistory } from '@/utils/types';
@@ -38,7 +38,8 @@ export default class Main extends Component<IMainState, Props> {
       today: this.dateModel.today,
       historyType: this.mainModel.historyType,
     };
-    this.mainModel.getHistoryCard(this.$state!.today);
+
+    asyncSetState(this.mainModel.getHistoryCard(this.$state!.today));
   }
 
   template() {
@@ -149,10 +150,10 @@ export default class Main extends Component<IMainState, Props> {
   }
 
   toggleIncomBtn(e: any) {
-    this.mainModel.toggleType('income');
+    asyncSetState(this.mainModel.toggleType('income'));
   }
 
   toggleExpenseBtn(e: any) {
-    this.mainModel.toggleType('expense');
+    asyncSetState(this.mainModel.toggleType('expense'));
   }
 }

--- a/client/src/Components/Main/index.ts
+++ b/client/src/Components/Main/index.ts
@@ -26,6 +26,7 @@ export default class Main extends Component<IMainState, Props> {
   dateModel!: TodayModelType;
 
   setup() {
+    this.classIDF = 'Main';
     // main 모델(history) 구독
     this.mainModel = MainModel;
     this.mainModel.subscribe(this.mainModel.key, this);

--- a/client/src/Core/Component.ts
+++ b/client/src/Core/Component.ts
@@ -5,12 +5,14 @@ export default class Component<S extends State, P extends Props> {
   $state?: S;
   $props?: P;
   eventlisteners: EventListener[];
+  classIDF: string;
 
   constructor($target: HTMLElement, $state?: S, $props?: P) {
     this.$target = $target;
     this.$state = $state;
     this.$props = $props;
     this.eventlisteners = [];
+    this.classIDF = '';
     this.setup();
     this.render();
     this.setEvent();

--- a/client/src/Core/Observable.ts
+++ b/client/src/Core/Observable.ts
@@ -26,7 +26,7 @@ export default class Observable {
 
   async notify(key: string, data: any): Promise<curType> {
     return this._observers[key].map((observer: any) => ({
-      name: observer.constructor.name,
+      name: observer.classIDF,
       observer,
       data,
     }));

--- a/client/src/Core/Observable.ts
+++ b/client/src/Core/Observable.ts
@@ -1,5 +1,6 @@
 /* any는 나중에 꼭꼮꼭 타입을 바꿔주도록 해보아요 */
 import { Store } from '@/Core/Store';
+import { curType } from '@/utils/types';
 
 export default class Observable {
   private _observers: any;
@@ -23,7 +24,11 @@ export default class Observable {
     );
   }
 
-  notify(key: string, data: any) {
-    this._observers[key].forEach((observer: any) => observer.setState(data));
+  async notify(key: string, data: any): Promise<curType> {
+    return this._observers[key].map((observer: any) => ({
+      name: observer.constructor.name,
+      observer,
+      data,
+    }));
   }
 }

--- a/client/src/Model/DateModel.ts
+++ b/client/src/Model/DateModel.ts
@@ -1,5 +1,5 @@
 import Observable from '@/Core/Observable';
-import { Today } from '@/utils/types';
+import { curType, Today } from '@/utils/types';
 
 class DateModel extends Observable {
   today: Today;
@@ -26,7 +26,7 @@ class DateModel extends Observable {
 
     this.today = { year, month };
     const prevDate = { today: this.today };
-    this.notify(this.key, prevDate);
+    return this.notify(this.key, prevDate);
   }
 
   getNextData() {
@@ -39,7 +39,7 @@ class DateModel extends Observable {
 
     this.today = { year, month };
     const nextDate = { today: this.today };
-    this.notify(this.key, nextDate);
+    return this.notify(this.key, nextDate);
   }
 }
 

--- a/client/src/Model/MainModel.ts
+++ b/client/src/Model/MainModel.ts
@@ -17,20 +17,21 @@ class MainModel extends Observable {
   }
 
   getHistoryCard(today: Today) {
+    console.log(today);
     this.filterHistoryCardsByMonth(today);
-    this.notify(this.key, { historyCards: this.historyCards });
+    return this.notify(this.key, { historyCards: this.historyCards });
   }
 
   addHistory(history: IHistory) {
     const nextHistory = [...this.historyCards, history];
     this.historyCards = nextHistory;
 
-    this.notify(this.key, { historyCards: nextHistory });
+    return this.notify(this.key, { historyCards: nextHistory });
   }
 
   toggleType(nextType: typeString) {
     this.historyType[nextType] = !this.historyType[nextType];
-    this.notify(this.key, { historyType: this.historyType });
+    return this.notify(this.key, { historyType: this.historyType });
   }
 
   filterHistoryCardsByMonth(today: Today): void {

--- a/client/src/View/MainView/index.ts
+++ b/client/src/View/MainView/index.ts
@@ -1,6 +1,6 @@
 import './styles';
 import Component from '@/Core/Component';
-import { addComma, html } from '@/utils/helper';
+import { addComma, asyncSetState, html } from '@/utils/helper';
 import { IValidationType, MainModelType, Props, State } from '@/utils/types';
 import { svgIcons } from '@/assets/svgIcons';
 import Main from '@/Components/Main';
@@ -173,7 +173,7 @@ export default class MainView extends Component<State, Props> {
       price: parseInt($priceInput.value.replace(/,/g, '')),
     };
 
-    this.model.addHistory(newHistory);
+    asyncSetState(this.model.addHistory(newHistory));
 
     $categoryInput.value = '';
     $contentInput.value = '';
@@ -190,7 +190,7 @@ export default class MainView extends Component<State, Props> {
     this.checkValidated();
   }
 
-  validateYear(e: HTMLInputElement) {
+  validateYear(e: KeyboardEvent) {
     let year: number = parseInt((<HTMLInputElement>e.target).value);
     if (!year) return;
 
@@ -199,7 +199,7 @@ export default class MainView extends Component<State, Props> {
     (<HTMLInputElement>e.target).value = String(year);
     this.date.year = year;
   }
-  validateMonth(e: HTMLInputElement) {
+  validateMonth(e: KeyboardEvent) {
     let month: number = parseInt((<HTMLInputElement>e.target).value);
     if (!month) return;
 
@@ -208,7 +208,7 @@ export default class MainView extends Component<State, Props> {
     (<HTMLInputElement>e.target).value = String(month);
     this.date.month = month;
   }
-  validateDay(e: HTMLInputElement) {
+  validateDay(e: KeyboardEvent) {
     const lastDay = new Date(this.date.year, this.date.month, 0).getDate();
     let day: number = parseInt((<HTMLInputElement>e.target).value);
     if (!day) return;
@@ -219,26 +219,30 @@ export default class MainView extends Component<State, Props> {
     this.date.day = day;
   }
 
-  validateCategory(e: HTMLInputElement) {
-    if (e.target.value === '') this.validation.category = false;
+  validateCategory(e: KeyboardEvent) {
+    if ((<HTMLInputElement>e.target).value === '')
+      this.validation.category = false;
     else this.validation.category = true;
     this.checkValidated();
   }
-  validateContent(e: HTMLInputElement) {
-    if (e.target.value === '') this.validation.content = false;
+  validateContent(e: KeyboardEvent) {
+    if ((<HTMLInputElement>e.target).value === '')
+      this.validation.content = false;
     else this.validation.content = true;
     this.checkValidated();
   }
-  validatePayment(e: HTMLInputElement) {
-    if (e.target.value === '') this.validation.payment = false;
+  validatePayment(e: KeyboardEvent) {
+    if ((<HTMLInputElement>e.target).value === '')
+      this.validation.payment = false;
     else this.validation.payment = true;
     this.checkValidated();
   }
-  validatePrice(e: HTMLInputElement) {
-    if (e.target.value === '') this.validation.price = false;
+  validatePrice(e: KeyboardEvent) {
+    if ((<HTMLInputElement>e.target).value === '')
+      this.validation.price = false;
     else {
-      const price = e.target.value.replace(/,/g, '');
-      e.target.value = addComma(price);
+      const price = (<HTMLInputElement>e.target).value.replace(/,/g, '');
+      (<HTMLInputElement>e.target).value = addComma(price);
       this.validation.price = true;
     }
     this.checkValidated();

--- a/client/src/View/MainView/index.ts
+++ b/client/src/View/MainView/index.ts
@@ -18,6 +18,7 @@ export default class MainView extends Component<State, Props> {
   };
 
   setup() {
+    this.classIDF = 'MainView';
     this.model = MainModel;
     this.date = {
       year: new Date().getFullYear(),

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -1,3 +1,5 @@
+import Component from '@/Core/Component';
+
 /**
 import { histories } from './../assets/dummy';
  * @example
@@ -8,6 +10,15 @@ interface Model {
   unsubscribe: (key: string, observer: any) => void;
   notify: (key: string, data: any) => void;
 }
+
+export type ObserversType = {
+  [key: string]: { new (): Component<State, Props> }[];
+};
+
+export type subscribeType = {
+  key: string;
+  observer: { new (): Component<State, Props> };
+};
 
 /**
  * @example
@@ -49,19 +60,14 @@ export type Today = {
 export interface TodayModelType extends Model {
   today: Today;
   key: string;
-  getPrevDate: () => void;
-  getNextData: () => void;
+  getPrevDate: () => Promise<curType>;
+  getNextData: () => Promise<curType>;
 }
 
 export interface CalendarState extends State {
   today: Today;
   historyCards?: IHistory[];
   historyType: HistoryType;
-  histories: {
-    [key: string]: {
-      history: { income?: number; outcome?: number; amount: number | null };
-    };
-  };
 }
 
 /**
@@ -78,9 +84,9 @@ export interface MainModelType extends Model {
   key: string;
   historyCards: IHistory[];
   historyType: HistoryType;
-  getHistoryCard: (today: Today) => void;
-  addHistory: (history: IHistory) => void;
-  toggleType: (nextType: typeString) => void;
+  getHistoryCard: (today: Today) => Promise<curType>;
+  addHistory: (history: IHistory) => Promise<curType>;
+  toggleType: (nextType: typeString) => Promise<curType>;
 }
 
 export interface DateState extends State {
@@ -108,3 +114,20 @@ export interface IValidationType {
   payment: boolean;
   price: boolean;
 }
+
+/**
+ * @example
+ * 비동기 setState 데이터 관련 타입
+ */
+export type curType = {
+  name: string;
+  observer: any;
+  data: any;
+};
+
+export type accType = {
+  [key: string]: {
+    observer: any;
+    data: any;
+  };
+};


### PR DESCRIPTION
### 변경사항

- 기존 동기 순차 방식의 `setState` 메서드를 비동기 방식으로 변경했습니다.
- 비동기 방식으로 변경함에 따라 `Promise.all` 내장 함수를 통해 `setState`를 일괄(batch)처리 합니다.
- 중복되는 옵저버(컴포넌트)가 있는 경우 변경될 데이터를 합성(composition)하고 하나의 `setState` 메서드만 호출합니다.

### 주의점 & 추가 구현 사항

- 비동기 방식으로 변경됨에 따라 모델 데이터 업데이트 메서드를 선호출 후 변경된 데이터를 건네받아 다음 업데이트 메서드를 호출하는 경우 즉각 상태값이 변경되지 않으므로 사용에 주의가 필요합니다.
- 모델에 선언된 값을 직접 들고와서 인자로 전달해야 할 거 같습니다.
- 타입 구축 어떡하죠오오오!!!? ㅠㅠㅠㅠ