### PR TITLE
[feature] Calendar 컴포넌트 내역 조회 서버 API 연동 및 기능 작성

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",
+        "dayjs": "^1.10.6",
         "typescript": "^4.3.5"
       },
       "devDependencies": {
@@ -3720,6 +3721,11 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -14218,6 +14224,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
     },
     "debug": {
       "version": "4.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "dayjs": "^1.10.6",
     "typescript": "^4.3.5"
   }
 }

--- a/client/src/Components/Calendar/index.ts
+++ b/client/src/Components/Calendar/index.ts
@@ -4,7 +4,7 @@ import { html, addComma, asyncSetState } from '@/utils/helper';
 import {
   Props,
   TodayModelType,
-  MainModelType,
+  HistoryModelType,
   CalendarState,
   CalendarControllerType,
 } from '@/utils/types';
@@ -14,7 +14,7 @@ import CalendarController from '@/Controller/CalendarController';
 
 export default class Calendar extends Component<CalendarState, Props> {
   todayModel!: TodayModelType;
-  mainModel!: MainModelType;
+  mainModel!: HistoryModelType;
   calendarController!: CalendarControllerType;
 
   setup() {

--- a/client/src/Components/Calendar/index.ts
+++ b/client/src/Components/Calendar/index.ts
@@ -1,6 +1,6 @@
 import Component from '@/Core/Component';
 import './styles';
-import { html, addComma, asyncSetState } from '@/utils/helper';
+import { html, asyncSetState } from '@/utils/helper';
 import {
   Props,
   TodayModelType,
@@ -14,25 +14,25 @@ import CalendarController from '@/Controller/CalendarController';
 
 export default class Calendar extends Component<CalendarState, Props> {
   todayModel!: TodayModelType;
-  mainModel!: HistoryModelType;
+  historyModel!: HistoryModelType;
   calendarController!: CalendarControllerType;
 
   setup() {
     this.todayModel = DateModel;
     this.todayModel.subscribe(this.todayModel.key, this);
 
-    this.mainModel = HistoryModel;
-    this.mainModel.subscribe(this.mainModel.key, this);
+    this.historyModel = HistoryModel;
+    this.historyModel.subscribe(this.historyModel.key, this);
 
     this.calendarController = CalendarController;
 
     this.$state = {
       today: this.todayModel.today,
-      historyCards: this.mainModel.historyCards,
-      historyCardForToday: this.mainModel.historyCardForToday,
+      historyCards: this.historyModel.historyCards,
+      historyCardForToday: this.historyModel.historyCardForToday,
     };
 
-    asyncSetState(this.mainModel.getHistoryCard(this.$state!.today));
+    asyncSetState(this.historyModel.getHistoryCard(this.$state!.today));
   }
 
   template() {
@@ -64,7 +64,7 @@ export default class Calendar extends Component<CalendarState, Props> {
     const tid = (<HTMLElement>e.target).closest('.history-data')?.id;
     const date = tid?.match(regex)?.[0];
     asyncSetState(
-      this.mainModel.getTodaysHistoryCard({ ...today, day: +date! })
+      this.historyModel.getTodaysHistoryCard({ ...today, day: +date! })
     );
   }
 
@@ -74,6 +74,6 @@ export default class Calendar extends Component<CalendarState, Props> {
 
   setUnmount() {
     this.todayModel.unsubscribe(this.todayModel.key, this);
-    this.mainModel.unsubscribe(this.mainModel.key, this);
+    this.historyModel.unsubscribe(this.historyModel.key, this);
   }
 }

--- a/client/src/Components/Calendar/index.ts
+++ b/client/src/Components/Calendar/index.ts
@@ -9,7 +9,7 @@ import {
   CalendarControllerType,
 } from '@/utils/types';
 import DateModel from '@/Model/DateModel';
-import MainModel from '@/Model/MainModel';
+import HistoryModel from '@/Model/HistoryModel';
 import CalendarController from '@/Controller/CalendarController';
 
 export default class Calendar extends Component<CalendarState, Props> {
@@ -21,7 +21,7 @@ export default class Calendar extends Component<CalendarState, Props> {
     this.todayModel = DateModel;
     this.todayModel.subscribe(this.todayModel.key, this);
 
-    this.mainModel = MainModel;
+    this.mainModel = HistoryModel;
     this.mainModel.subscribe(this.mainModel.key, this);
 
     this.calendarController = CalendarController;

--- a/client/src/Components/Header/index.ts
+++ b/client/src/Components/Header/index.ts
@@ -3,7 +3,7 @@ import Component from '@/Core/Component';
 import { html } from '@/utils/helper';
 import { $router } from '@/Core/Router';
 import { svgIcons } from '@/assets/svgIcons';
-import { MainModelType, Props, TodayModelType } from '@/utils/types';
+import { HistoryModelType, Props, TodayModelType } from '@/utils/types';
 import DateModel from '@/Model/DateModel';
 import { DateState } from '@/utils/types';
 import HeaderController from '@/Controller/HeaderController';
@@ -11,7 +11,7 @@ import HeaderController from '@/Controller/HeaderController';
 export default class Header extends Component<DateState, Props> {
   dateModel!: TodayModelType;
   headerController!: any;
-  mainModel!: MainModelType;
+  mainModel!: HistoryModelType;
 
   setup() {
     this.classIDF = 'Header';

--- a/client/src/Components/Header/index.ts
+++ b/client/src/Components/Header/index.ts
@@ -75,7 +75,7 @@ export default class Header extends Component<DateState, Props> {
     });
     this.addEvent('click', '#menu-user', () => {
       $router.push('/user');
-      this.headerController.changeMenu();
+      this.headerController.changeMenu(this.$target);
     });
   }
 

--- a/client/src/Components/Header/index.ts
+++ b/client/src/Components/Header/index.ts
@@ -75,31 +75,8 @@ export default class Header extends Component<DateState, Props> {
     });
     this.addEvent('click', '#menu-user', () => {
       $router.push('/user');
-      this.changeMenu();
+      this.headerController.changeMenu();
     });
-  }
-
-  changeMenu() {
-    const path = history.state.path as string;
-    this.$target
-      .querySelectorAll('li.menu-list')
-      .forEach((elem: Element) => elem.removeAttribute('active'));
-    switch (path) {
-      case '/main':
-        this.$target.querySelector('li#menu-main')?.setAttribute('active', '');
-        break;
-      case '/calendar':
-        this.$target
-          .querySelector('li#menu-calendar')
-          ?.setAttribute('active', '');
-        break;
-      case '/charts':
-        this.$target.querySelector('li#menu-chart')?.setAttribute('active', '');
-        break;
-      case '/user':
-        this.$target.querySelector('li#menu-user')?.setAttribute('active', '');
-        break;
-    }
   }
 
   removeEvent() {}

--- a/client/src/Components/HistoryDayCard/index.ts
+++ b/client/src/Components/HistoryDayCard/index.ts
@@ -112,19 +112,19 @@ export default class HistoryDayCard extends Component<
     }
 
     // 해당 월의 history 추출
-    const historyDates = historyList.map((history) => history.date);
+    const historyDates = historyList.map((history) => history.createAt);
     // 카드를 생성할 날짜를 중복 제거한 후 배열로 저장
     const dates = Array.from(new Set(historyDates)).sort().reverse();
 
     const histories = historyList.reduce(
       (acc: Record<string, IHistory[]>, history) => {
-        if (!acc[history.date]) {
-          acc[history.date] = [];
-          acc[history.date].push(history);
+        if (!acc[history.createAt]) {
+          acc[history.createAt] = [];
+          acc[history.createAt].push(history);
           return acc;
         }
 
-        acc[history.date].push(history);
+        acc[history.createAt].push(history);
         return acc;
       },
       {}

--- a/client/src/Components/HistoryDayCard/index.ts
+++ b/client/src/Components/HistoryDayCard/index.ts
@@ -45,7 +45,7 @@ export default class HistoryDayCard extends Component<
       historyType: this.historyModel.historyType,
     };
 
-    asyncSetState(this.historyModel.initState(this.$state.today));
+    asyncSetState(this.historyModel.getHistoryCard(this.$state.today));
   }
 
   template() {

--- a/client/src/Components/HistoryDayCard/index.ts
+++ b/client/src/Components/HistoryDayCard/index.ts
@@ -12,7 +12,7 @@ import {
 } from '@/utils/types';
 import { addComma, asyncSetState, html } from '@/utils/helper';
 import HistoryList from '@/Components/HistoryList';
-import MainModel from '@/Model/MainModel';
+import HistoryModel from '@/Model/HistoryModel';
 import DateModel from '@/Model/DateModel';
 
 interface IListStates extends State {
@@ -31,7 +31,7 @@ export default class HistoryDayCard extends Component<
 
   setup() {
     this.classIDF = 'HistoryDayCard';
-    this.historyModel = MainModel;
+    this.historyModel = HistoryModel;
     this.historyModel.subscribe(this.historyModel.key, this);
 
     this.dateModel = DateModel;
@@ -50,6 +50,8 @@ export default class HistoryDayCard extends Component<
   template() {
     const { onlyToday } = this.$props ?? { onlyToday: false };
     const { dates, histories } = this.updateList(onlyToday);
+    const { year, month } = this.$state!.today;
+    this.historyModel.initState({ year, month });
 
     return html`
       ${dates

--- a/client/src/Components/HistoryDayCard/index.ts
+++ b/client/src/Components/HistoryDayCard/index.ts
@@ -1,5 +1,6 @@
 import Component from '@/Core/Component';
 import './styles';
+import dayjs from 'dayjs';
 import {
   HistoryType,
   IHistory,
@@ -50,7 +51,6 @@ export default class HistoryDayCard extends Component<
   template() {
     const { onlyToday } = this.$props ?? { onlyToday: false };
     const { dates, histories } = this.updateList(onlyToday);
-    const { year, month } = this.$state!.today;
 
     return html`
       ${dates
@@ -99,10 +99,10 @@ export default class HistoryDayCard extends Component<
 
     const incomeSum = historyList
       .filter((history) => history.type === 1)
-      .reduce((acc, cur) => acc + cur.price, 0);
+      .reduce((acc, cur) => acc + Number(cur.price), 0);
     const expenseSum = historyList
       .filter((history) => history.type === 0)
-      .reduce((acc, cur) => acc + cur.price, 0);
+      .reduce((acc, cur) => acc + Number(cur.price), 0);
 
     if (!onlyToday) {
       $totalNum!.innerText = historyList.length.toString();
@@ -110,24 +110,23 @@ export default class HistoryDayCard extends Component<
       $expenseSum!.innerText = addComma(expenseSum!.toString());
     }
 
-    historyList.forEach((history) => console.log(history.createdAt));
-
     // 해당 월의 history 추출
-    const historyDates = historyList.map((history) => history.createdAt);
+    const historyDates = historyList.map((history) =>
+      dayjs(history.createdAt).format('YYYY-MM-DD')
+    );
     // 카드를 생성할 날짜를 중복 제거한 후 배열로 저장
     const dates = Array.from(new Set(historyDates)).sort().reverse();
 
-    console.log(historyDates);
-
     const histories = historyList.reduce(
       (acc: Record<string, IHistory[]>, history) => {
-        if (!acc[history.createdAt]) {
-          acc[history.createdAt] = [];
-          acc[history.createdAt].push(history);
+        const date = dayjs(history.createdAt).format('YYYY-MM-DD');
+        if (!acc[date]) {
+          acc[date] = [];
+          acc[date].push(history);
           return acc;
         }
 
-        acc[history.createdAt].push(history);
+        acc[date].push(history);
         return acc;
       },
       {}
@@ -143,16 +142,16 @@ export default class HistoryDayCard extends Component<
   getExpenseTotal(curDateHistories: IHistory[]) {
     return curDateHistories
       .filter((history) => history.type === 0)
-      .reduce((acc, cur, i) => {
-        return acc + cur.price;
+      .reduce((acc, cur) => {
+        return acc + Number(cur.price);
       }, 0);
   }
 
   getIncomeTotal(curDateHistories: IHistory[]) {
     return curDateHistories
       .filter((history) => history.type === 1)
-      .reduce((acc, cur, i) => {
-        return acc + cur.price;
+      .reduce((acc, cur) => {
+        return acc + Number(cur.price);
       }, 0);
   }
 

--- a/client/src/Components/HistoryDayCard/index.ts
+++ b/client/src/Components/HistoryDayCard/index.ts
@@ -4,7 +4,7 @@ import {
   HistoryType,
   IHistory,
   IHistoryDayCardProps,
-  MainModelType,
+  HistoryModelType,
   Props,
   State,
   Today,
@@ -26,7 +26,7 @@ export default class HistoryDayCard extends Component<
   IListStates,
   IHistoryDayCardProps
 > {
-  historyModel!: MainModelType;
+  historyModel!: HistoryModelType;
   dateModel!: TodayModelType;
 
   setup() {

--- a/client/src/Components/HistoryDayCard/index.ts
+++ b/client/src/Components/HistoryDayCard/index.ts
@@ -44,14 +44,13 @@ export default class HistoryDayCard extends Component<
       historyType: this.historyModel.historyType,
     };
 
-    asyncSetState(this.historyModel.getHistoryCard(this.$state!.today));
+    asyncSetState(this.historyModel.initState(this.$state.today));
   }
 
   template() {
     const { onlyToday } = this.$props ?? { onlyToday: false };
     const { dates, histories } = this.updateList(onlyToday);
     const { year, month } = this.$state!.today;
-    this.historyModel.initState({ year, month });
 
     return html`
       ${dates
@@ -111,20 +110,24 @@ export default class HistoryDayCard extends Component<
       $expenseSum!.innerText = addComma(expenseSum!.toString());
     }
 
+    historyList.forEach((history) => console.log(history.createdAt));
+
     // 해당 월의 history 추출
-    const historyDates = historyList.map((history) => history.createAt);
+    const historyDates = historyList.map((history) => history.createdAt);
     // 카드를 생성할 날짜를 중복 제거한 후 배열로 저장
     const dates = Array.from(new Set(historyDates)).sort().reverse();
 
+    console.log(historyDates);
+
     const histories = historyList.reduce(
       (acc: Record<string, IHistory[]>, history) => {
-        if (!acc[history.createAt]) {
-          acc[history.createAt] = [];
-          acc[history.createAt].push(history);
+        if (!acc[history.createdAt]) {
+          acc[history.createdAt] = [];
+          acc[history.createdAt].push(history);
           return acc;
         }
 
-        acc[history.createAt].push(history);
+        acc[history.createdAt].push(history);
         return acc;
       },
       {}

--- a/client/src/Components/InputBar/index.ts
+++ b/client/src/Components/InputBar/index.ts
@@ -9,7 +9,7 @@ import {
   IValidationType,
   IHistory,
 } from '@/utils/types';
-import MainModel from '@/Model/MainModel';
+import HistoryModel from '@/Model/HistoryModel';
 
 export default class InputBar extends Component<State, Props> {
   model!: MainModelType;
@@ -23,7 +23,7 @@ export default class InputBar extends Component<State, Props> {
 
   setup() {
     this.classIDF = 'InputBar';
-    this.model = MainModel;
+    this.model = HistoryModel;
     this.date = {
       year: new Date().getFullYear(),
       month: new Date().getMonth() + 1,

--- a/client/src/Components/InputBar/index.ts
+++ b/client/src/Components/InputBar/index.ts
@@ -157,12 +157,13 @@ export default class InputBar extends Component<State, Props> {
     ) as HTMLInputElement;
 
     const newHistory: IHistory = {
-      date: `${this.date.year}-${this.date.month}-${this.date.day}`,
+      createAt: `${this.date.year}-${this.date.month}-${this.date.day}`,
       type: 0,
       category: $categoryInput.value,
       content: $contentInput.value,
       payment: $paymentInput.value,
       price: parseInt($priceInput.value.replace(/,/g, '')),
+      id: (Math.random() * 10) >> 0,
     };
 
     asyncSetState(this.model.addHistory(newHistory));

--- a/client/src/Components/InputBar/index.ts
+++ b/client/src/Components/InputBar/index.ts
@@ -5,14 +5,14 @@ import { svgIcons } from '@/assets/svgIcons';
 import {
   Props,
   State,
-  MainModelType,
+  HistoryModelType,
   IValidationType,
   IHistory,
 } from '@/utils/types';
 import HistoryModel from '@/Model/HistoryModel';
 
 export default class InputBar extends Component<State, Props> {
-  model!: MainModelType;
+  model!: HistoryModelType;
   inputCondition: boolean[] = new Array();
   validation!: IValidationType;
   date!: {

--- a/client/src/Components/Main/index.ts
+++ b/client/src/Components/Main/index.ts
@@ -2,7 +2,7 @@ import Component from '@/Core/Component';
 import './styles';
 import { MainModelType, Props, State, Today, HistoryType } from '@/utils/types';
 import { asyncSetState, html } from '@/utils/helper';
-import MainModel from '@/Model/MainModel';
+import HistoryModel from '@/Model/HistoryModel';
 import { IHistory } from '@/utils/types';
 import { svgIcons } from '@/assets/svgIcons';
 import HistoryDayCard from '@/Components/HistoryDayCard/index';
@@ -17,7 +17,7 @@ export default class Main extends Component<IMainState, Props> {
   historyModel!: MainModelType;
 
   setup() {
-    this.historyModel = MainModel;
+    this.historyModel = HistoryModel;
   }
 
   template() {

--- a/client/src/Components/Main/index.ts
+++ b/client/src/Components/Main/index.ts
@@ -1,6 +1,12 @@
 import Component from '@/Core/Component';
 import './styles';
-import { MainModelType, Props, State, Today, HistoryType } from '@/utils/types';
+import {
+  HistoryModelType,
+  Props,
+  State,
+  Today,
+  HistoryType,
+} from '@/utils/types';
 import { asyncSetState, html } from '@/utils/helper';
 import HistoryModel from '@/Model/HistoryModel';
 import { IHistory } from '@/utils/types';
@@ -14,7 +20,7 @@ interface IMainState extends State {
 }
 
 export default class Main extends Component<IMainState, Props> {
-  historyModel!: MainModelType;
+  historyModel!: HistoryModelType;
 
   setup() {
     this.historyModel = HistoryModel;

--- a/client/src/Components/PriceBar/index.ts
+++ b/client/src/Components/PriceBar/index.ts
@@ -1,11 +1,11 @@
 import './styles';
 import Component from '@/Core/Component';
-import { Props, State, MainModelType } from '@/utils/types';
+import { Props, State, HistoryModelType } from '@/utils/types';
 import { html, addComma } from '@/utils/helper';
 import HistoryModel from '@/Model/HistoryModel';
 
 export default class PriceBar extends Component<State, Props> {
-  model!: MainModelType;
+  model!: HistoryModelType;
 
   setup() {
     this.classIDF = 'PriceBar';

--- a/client/src/Components/PriceBar/index.ts
+++ b/client/src/Components/PriceBar/index.ts
@@ -2,14 +2,14 @@ import './styles';
 import Component from '@/Core/Component';
 import { Props, State, MainModelType } from '@/utils/types';
 import { html, addComma } from '@/utils/helper';
-import MainModel from '@/Model/MainModel';
+import HistoryModel from '@/Model/HistoryModel';
 
 export default class PriceBar extends Component<State, Props> {
   model!: MainModelType;
 
   setup() {
     this.classIDF = 'PriceBar';
-    this.model = MainModel;
+    this.model = HistoryModel;
     this.model.subscribe(this.model.key, this);
   }
 

--- a/client/src/Components/PriceBar/index.ts
+++ b/client/src/Components/PriceBar/index.ts
@@ -14,7 +14,7 @@ export default class PriceBar extends Component<State, Props> {
   }
 
   template() {
-    const { amount, income, outcome } = this.model.filterHistoryPriceAmount();
+    const { amount, income, outcome } = this.model.getHistoryPayAmount();
     return html`
       <div class="in-outcome">
         <span class="price-content income"

--- a/client/src/Components/User/index.ts
+++ b/client/src/Components/User/index.ts
@@ -45,7 +45,7 @@ export default class User extends Component<UserState, Props> {
   }
 
   setEvent() {
-    this.addEvent('click', '.logout-btn', this.handleLogOut);
+    this.addEvent('click', '.logout-btn', this.handleLogOut.bind(this));
 
     this.addEvent('dblclick', '.user-payments', (e: Event) => {
       const target = e.target as HTMLElement;

--- a/client/src/Controller/CalendarController.ts
+++ b/client/src/Controller/CalendarController.ts
@@ -6,6 +6,7 @@ import {
 } from '@/utils/types';
 import { addComma, html, makeDateForm } from '@/utils/helper';
 import { IHistory } from '@/utils/types';
+import dayjs from 'dayjs';
 
 const SEVEN_DAYS = 7;
 const SIX_DAYS = 6;
@@ -90,24 +91,25 @@ class CalendarController {
   private filterHistories(historyCards: IHistory[]) {
     const histories: { [key: string]: HistoryTypeForDate } = {};
     historyCards?.forEach((history) => {
-      const { date, type, price } = history;
+      const { createdAt, type, price } = history;
+      const date = dayjs(createdAt).format('YYYY-MM-DD');
       const { income, outcome, amount } =
         histories[date]?.history ?? this.inititalState.history;
 
       if (type === INCOME) {
         histories[date] = {
           history: {
-            income: income ? income + price : price,
+            income: income ? +income + +price : +price,
             outcome,
-            amount: amount ? amount + price : price,
+            amount: amount ? +amount + +price : +price,
           },
         };
       } else if (type === OUTCOME) {
         histories[date] = {
           history: {
             income,
-            outcome: outcome ? outcome + price : -price,
-            amount: amount ? amount + price : -price,
+            outcome: outcome ? +outcome + -price : -price,
+            amount: amount ? +amount + -price : -price,
           },
         };
       }

--- a/client/src/Controller/HeaderController.ts
+++ b/client/src/Controller/HeaderController.ts
@@ -10,13 +10,12 @@ class HeaderController {
   constructor() {
     this.historyModel = HistoryModel;
     this.dateModel = DateModel;
-    // console.log(this.historyModel);
   }
 
   handleClickPrevBtn() {
     asyncSetState(
       this.dateModel.getPrevDate(),
-      this.historyModel.getHistoryCard(this.dateModel.today),
+      this.historyModel.initState(this.dateModel.today),
       this.historyModel.initHistoryForToday()
     );
   }
@@ -24,7 +23,7 @@ class HeaderController {
   handleClickNextBtn() {
     asyncSetState(
       this.dateModel.getNextData(),
-      this.historyModel.getHistoryCard(this.dateModel.today),
+      this.historyModel.initState(this.dateModel.today),
       this.historyModel.initHistoryForToday()
     );
   }
@@ -43,6 +42,9 @@ class HeaderController {
         break;
       case '/charts':
         $target.querySelector('li#menu-chart')?.setAttribute('active', '');
+        break;
+      case '/user':
+        $target.querySelector('li#menu-user')?.setAttribute('active', '');
         break;
     }
   }

--- a/client/src/Controller/HeaderController.ts
+++ b/client/src/Controller/HeaderController.ts
@@ -15,7 +15,7 @@ class HeaderController {
   handleClickPrevBtn() {
     asyncSetState(
       this.dateModel.getPrevDate(),
-      this.historyModel.initState(this.dateModel.today),
+      this.historyModel.getHistoryCard(this.dateModel.today),
       this.historyModel.initHistoryForToday()
     );
   }
@@ -23,7 +23,7 @@ class HeaderController {
   handleClickNextBtn() {
     asyncSetState(
       this.dateModel.getNextData(),
-      this.historyModel.initState(this.dateModel.today),
+      this.historyModel.getHistoryCard(this.dateModel.today),
       this.historyModel.initHistoryForToday()
     );
   }

--- a/client/src/Controller/HeaderController.ts
+++ b/client/src/Controller/HeaderController.ts
@@ -1,10 +1,10 @@
 import HistoryModel from '@/Model/HistoryModel';
-import { MainModelType, TodayModelType } from '@/utils/types';
+import { HistoryModelType, TodayModelType } from '@/utils/types';
 import DateModel from '@/Model/DateModel';
 import { asyncSetState } from '@/utils/helper';
 
 class HeaderController {
-  historyModel!: MainModelType;
+  historyModel!: HistoryModelType;
   dateModel!: TodayModelType;
 
   constructor() {

--- a/client/src/Controller/HeaderController.ts
+++ b/client/src/Controller/HeaderController.ts
@@ -1,4 +1,4 @@
-import MainModel from '@/Model/MainModel';
+import HistoryModel from '@/Model/HistoryModel';
 import { MainModelType, TodayModelType } from '@/utils/types';
 import DateModel from '@/Model/DateModel';
 import { asyncSetState } from '@/utils/helper';
@@ -8,7 +8,7 @@ class HeaderController {
   dateModel!: TodayModelType;
 
   constructor() {
-    this.historyModel = MainModel;
+    this.historyModel = HistoryModel;
     this.dateModel = DateModel;
     // console.log(this.historyModel);
   }

--- a/client/src/Model/HistoryModel.ts
+++ b/client/src/Model/HistoryModel.ts
@@ -33,8 +33,9 @@ class HistoryModel extends Observable {
   }
 
   async initState({ year, month }: Today) {
-    const res = await getHistories({ year, month });
-    console.log(res);
+    const { data } = await getHistories({ year, month });
+    const { historyList } = data;
+    console.log(historyList);
   }
 
   getHistoryCard(today: Today) {
@@ -64,19 +65,20 @@ class HistoryModel extends Observable {
   filterHistoryCardsByMonth(today: Today): void {
     this.historyCards = dummyhistories
       .filter((history) => {
-        const [year, month, _] = history.create_time
+        const [year, month, _] = history.createAt
           .split('-')
           .map((d) => parseInt(d));
         return today.year === year && today.month === month;
       })
       .map((history) => {
         return {
-          date: history.create_time,
+          createAt: history.createAt,
           type: history.type,
           category: history.category,
           content: history.content,
           payment: history.payment,
           price: history.price,
+          id: history.id,
         };
       });
   }
@@ -99,7 +101,7 @@ class HistoryModel extends Observable {
     const { year, month, day } = today;
     const date = makeDateForm({ year, month, day: day! });
     const historyCardsForToday = this.historyCards.filter(
-      (history) => history.date === date
+      (history) => history.createAt === date
     );
     this.historyCardForToday = historyCardsForToday;
   }

--- a/client/src/Model/HistoryModel.ts
+++ b/client/src/Model/HistoryModel.ts
@@ -32,10 +32,12 @@ class HistoryModel extends Observable {
     this.historyCardForToday = [];
   }
 
-  async initState({ year, month }: Today) {
+  async initState(today: Today) {
+    const { year, month } = today;
     const { data } = await getHistories({ year, month });
     const { historyList } = data;
-    console.log(historyList);
+    this.historyCards = historyList;
+    return this.notify(this.key, { historyCards: historyList });
   }
 
   getHistoryCard(today: Today) {
@@ -65,14 +67,14 @@ class HistoryModel extends Observable {
   filterHistoryCardsByMonth(today: Today): void {
     this.historyCards = dummyhistories
       .filter((history) => {
-        const [year, month, _] = history.createAt
+        const [year, month, _] = history.createdAt
           .split('-')
           .map((d) => parseInt(d));
         return today.year === year && today.month === month;
       })
       .map((history) => {
         return {
-          createAt: history.createAt,
+          createdAt: history.createdAt,
           type: history.type,
           category: history.category,
           content: history.content,
@@ -101,7 +103,7 @@ class HistoryModel extends Observable {
     const { year, month, day } = today;
     const date = makeDateForm({ year, month, day: day! });
     const historyCardsForToday = this.historyCards.filter(
-      (history) => history.createAt === date
+      (history) => history.createdAt === date
     );
     this.historyCardForToday = historyCardsForToday;
   }

--- a/client/src/Model/HistoryModel.ts
+++ b/client/src/Model/HistoryModel.ts
@@ -1,3 +1,4 @@
+import { getHistories } from '@/api/history';
 import { dummyhistories } from '@/assets/dummy';
 import Observable from '@/Core/Observable';
 import { makeDateForm } from '@/utils/helper';
@@ -9,7 +10,7 @@ import {
   PriceAmountType,
 } from '@/utils/types';
 
-class MainModel extends Observable {
+class HistoryModel extends Observable {
   key: string = 'history';
   historyCards: IHistory[];
   historyType: HistoryType;
@@ -29,6 +30,11 @@ class MainModel extends Observable {
       outcome: 0,
     };
     this.historyCardForToday = [];
+  }
+
+  async initState({ year, month }: Today) {
+    const res = await getHistories({ year, month });
+    console.log(res);
   }
 
   getHistoryCard(today: Today) {
@@ -106,4 +112,4 @@ class MainModel extends Observable {
   }
 }
 
-export default new MainModel();
+export default new HistoryModel();

--- a/client/src/api/history.ts
+++ b/client/src/api/history.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const APIENDPOINT = `http://localhost:3000/api/histories`;
+
+export const getHistories = async ({
+  year,
+  month,
+}: {
+  year: number;
+  month: number;
+}) =>
+  axios.get(`${APIENDPOINT}?year=${year}&month=${month}`, {
+    withCredentials: true,
+  });

--- a/client/src/assets/dummy.ts
+++ b/client/src/assets/dummy.ts
@@ -8,7 +8,7 @@ export const dummyhistories = [
     price: 54000,
     content: '사이드 테이블 구매',
     type: 0,
-    createAt: '2021-06-29',
+    createdAt: '2021-06-29',
   },
   {
     id: 2,
@@ -18,7 +18,7 @@ export const dummyhistories = [
     price: 9000,
     content: '엽기떡볶이',
     type: 0,
-    createAt: '2021-06-30',
+    createdAt: '2021-06-30',
   },
   {
     id: 3,
@@ -28,7 +28,7 @@ export const dummyhistories = [
     price: 45340,
     content: '후불 교통비 결제',
     type: 0,
-    createAt: '2021-07-01',
+    createdAt: '2021-07-01',
   },
   {
     id: 4,
@@ -38,7 +38,7 @@ export const dummyhistories = [
     price: 45340,
     content: '온라인 세미나 신청',
     type: 0,
-    createAt: '2021-07-02',
+    createdAt: '2021-07-02',
   },
   {
     id: 5,
@@ -48,7 +48,7 @@ export const dummyhistories = [
     price: 1490000,
     content: '시카고 뮤지컬',
     type: 0,
-    createAt: '2021-07-03',
+    createdAt: '2021-07-03',
   },
   {
     id: 6,
@@ -58,7 +58,7 @@ export const dummyhistories = [
     price: 125300,
     content: '체육관 수강 등록',
     type: 0,
-    createAt: '2021-07-03',
+    createdAt: '2021-07-03',
   },
   {
     id: 7,
@@ -68,7 +68,7 @@ export const dummyhistories = [
     price: 6400,
     content: '종량제 봉투 구입',
     type: 0,
-    createAt: '2021-07-05',
+    createdAt: '2021-07-05',
   },
   {
     id: 8,
@@ -78,7 +78,7 @@ export const dummyhistories = [
     price: 1600,
     content: '신한카드 금융 이자',
     type: 1,
-    createAt: '2021-07-10',
+    createdAt: '2021-07-10',
   },
   {
     id: 9,
@@ -88,7 +88,7 @@ export const dummyhistories = [
     price: 1000,
     content: '우아한 형제들 캐시백',
     type: 1,
-    createAt: '2021-07-17',
+    createdAt: '2021-07-17',
   },
   {
     id: 10,
@@ -98,7 +98,7 @@ export const dummyhistories = [
     price: 60000,
     content: '건강검진 진행',
     type: 0,
-    createAt: '2021-07-20',
+    createdAt: '2021-07-20',
   },
   {
     id: 11,
@@ -108,7 +108,7 @@ export const dummyhistories = [
     price: 4000,
     content: '길거리 포장마차 분식 먹방',
     type: 0,
-    createAt: '2021-08-02',
+    createdAt: '2021-08-02',
   },
   {
     id: 12,
@@ -118,7 +118,7 @@ export const dummyhistories = [
     price: 10000,
     content: '친구와의 내기에서 승리!',
     type: 1,
-    createAt: '2021-08-07',
+    createdAt: '2021-08-07',
   },
   {
     id: 13,
@@ -128,7 +128,7 @@ export const dummyhistories = [
     price: 35000,
     content: '고급 일식 식당에서 친구와 식사 (내가 다 냄)',
     type: 0,
-    createAt: '2021-08-09',
+    createdAt: '2021-08-09',
   },
   {
     id: 14,
@@ -138,7 +138,7 @@ export const dummyhistories = [
     price: 2000000,
     content: '월급',
     type: 1,
-    createAt: '2021-08-10',
+    createdAt: '2021-08-10',
   },
   {
     id: 15,
@@ -148,7 +148,7 @@ export const dummyhistories = [
     price: 600000,
     content: '헬스장 1달치 등록',
     type: 0,
-    createAt: '2021-08-15',
+    createdAt: '2021-08-15',
   },
   {
     id: 16,
@@ -158,7 +158,7 @@ export const dummyhistories = [
     price: 600000,
     content: '헬스장 1달치 환불',
     type: 1,
-    createAt: '2021-08-15',
+    createdAt: '2021-08-15',
   },
 ];
 

--- a/client/src/assets/dummy.ts
+++ b/client/src/assets/dummy.ts
@@ -8,7 +8,7 @@ export const dummyhistories = [
     price: 54000,
     content: '사이드 테이블 구매',
     type: 0,
-    create_time: '2021-06-29',
+    createAt: '2021-06-29',
   },
   {
     id: 2,
@@ -18,7 +18,7 @@ export const dummyhistories = [
     price: 9000,
     content: '엽기떡볶이',
     type: 0,
-    create_time: '2021-06-30',
+    createAt: '2021-06-30',
   },
   {
     id: 3,
@@ -28,7 +28,7 @@ export const dummyhistories = [
     price: 45340,
     content: '후불 교통비 결제',
     type: 0,
-    create_time: '2021-07-01',
+    createAt: '2021-07-01',
   },
   {
     id: 4,
@@ -38,7 +38,7 @@ export const dummyhistories = [
     price: 45340,
     content: '온라인 세미나 신청',
     type: 0,
-    create_time: '2021-07-02',
+    createAt: '2021-07-02',
   },
   {
     id: 5,
@@ -48,7 +48,7 @@ export const dummyhistories = [
     price: 1490000,
     content: '시카고 뮤지컬',
     type: 0,
-    create_time: '2021-07-03',
+    createAt: '2021-07-03',
   },
   {
     id: 6,
@@ -58,7 +58,7 @@ export const dummyhistories = [
     price: 125300,
     content: '체육관 수강 등록',
     type: 0,
-    create_time: '2021-07-03',
+    createAt: '2021-07-03',
   },
   {
     id: 7,
@@ -68,7 +68,7 @@ export const dummyhistories = [
     price: 6400,
     content: '종량제 봉투 구입',
     type: 0,
-    create_time: '2021-07-05',
+    createAt: '2021-07-05',
   },
   {
     id: 8,
@@ -78,7 +78,7 @@ export const dummyhistories = [
     price: 1600,
     content: '신한카드 금융 이자',
     type: 1,
-    create_time: '2021-07-10',
+    createAt: '2021-07-10',
   },
   {
     id: 9,
@@ -88,7 +88,7 @@ export const dummyhistories = [
     price: 1000,
     content: '우아한 형제들 캐시백',
     type: 1,
-    create_time: '2021-07-17',
+    createAt: '2021-07-17',
   },
   {
     id: 10,
@@ -98,7 +98,7 @@ export const dummyhistories = [
     price: 60000,
     content: '건강검진 진행',
     type: 0,
-    create_time: '2021-07-20',
+    createAt: '2021-07-20',
   },
   {
     id: 11,
@@ -108,7 +108,7 @@ export const dummyhistories = [
     price: 4000,
     content: '길거리 포장마차 분식 먹방',
     type: 0,
-    create_time: '2021-08-02',
+    createAt: '2021-08-02',
   },
   {
     id: 12,
@@ -118,7 +118,7 @@ export const dummyhistories = [
     price: 10000,
     content: '친구와의 내기에서 승리!',
     type: 1,
-    create_time: '2021-08-07',
+    createAt: '2021-08-07',
   },
   {
     id: 13,
@@ -128,7 +128,7 @@ export const dummyhistories = [
     price: 35000,
     content: '고급 일식 식당에서 친구와 식사 (내가 다 냄)',
     type: 0,
-    create_time: '2021-08-09',
+    createAt: '2021-08-09',
   },
   {
     id: 14,
@@ -138,7 +138,7 @@ export const dummyhistories = [
     price: 2000000,
     content: '월급',
     type: 1,
-    create_time: '2021-08-10',
+    createAt: '2021-08-10',
   },
   {
     id: 15,
@@ -148,7 +148,7 @@ export const dummyhistories = [
     price: 600000,
     content: '헬스장 1달치 등록',
     type: 0,
-    create_time: '2021-08-15',
+    createAt: '2021-08-15',
   },
   {
     id: 16,
@@ -158,7 +158,7 @@ export const dummyhistories = [
     price: 600000,
     content: '헬스장 1달치 환불',
     type: 1,
-    create_time: '2021-08-15',
+    createAt: '2021-08-15',
   },
 ];
 

--- a/client/src/assets/dummy.ts
+++ b/client/src/assets/dummy.ts
@@ -167,8 +167,8 @@ export const category = [
   { id: 2, type: '식비' },
   { id: 3, type: '교통' },
   { id: 4, type: '쇼핑/뷰티' },
-  { id: 5, type: '의료/건강' },
-  { id: 6, type: '문화/여가' },
+  { id: 5, type: '여가' },
+  { id: 6, type: '문화' },
   { id: 7, type: '미분류' },
   { id: 8, type: '금융 이자' },
 ];

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -92,7 +92,7 @@ export interface HistoryModelType extends Model {
   filterHistoryCardByDay: (today: Today) => void;
   getTodaysHistoryCard: (today: Today) => Promise<curType>;
   initHistoryForToday: () => Promise<curType>;
-  initState: ({ year, month }: Today) => void;
+  initState: ({ year, month }: Today) => Promise<curType>;
 }
 
 export interface DateState extends State {
@@ -111,7 +111,7 @@ export type PriceAmountType = {
  * history 리스트 타입
  */
 export interface IHistory {
-  createAt: string;
+  createdAt: string;
   type: number;
   category: string;
   content: string;

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -111,12 +111,13 @@ export type PriceAmountType = {
  * history 리스트 타입
  */
 export interface IHistory {
-  date: string;
+  createAt: string;
   type: number;
   category: string;
   content: string;
   payment: string;
   price: number;
+  id: number;
 }
 
 export interface IValidationType {

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -72,7 +72,7 @@ export interface CalendarState extends State {
 
 /**
  * @example
- * MainModel 관련 타입
+ * HistoryModel 관련 타입
  */
 
 export type typeString = 'expense' | 'income';
@@ -80,7 +80,7 @@ export interface HistoryType {
   expense?: boolean;
   income?: boolean;
 }
-export interface MainModelType extends Model {
+export interface HistoryModelType extends Model {
   key: string;
   historyCards: IHistory[];
   historyType: HistoryType;
@@ -92,6 +92,7 @@ export interface MainModelType extends Model {
   filterHistoryCardByDay: (today: Today) => void;
   getTodaysHistoryCard: (today: Today) => Promise<curType>;
   initHistoryForToday: () => Promise<curType>;
+  initState: ({ year, month }: Today) => void;
 }
 
 export interface DateState extends State {

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -85,14 +85,12 @@ export interface HistoryModelType extends Model {
   historyCards: IHistory[];
   historyType: HistoryType;
   historyCardForToday: IHistory[];
-  getHistoryCard: (today: Today) => Promise<curType>;
+  getHistoryCard: ({ year, month }: Today) => Promise<curType>;
   addHistory: (history: IHistory) => Promise<curType>;
   toggleType: (nextType: typeString) => Promise<curType>;
-  filterHistoryPriceAmount: () => PriceAmountType;
-  filterHistoryCardByDay: (today: Today) => void;
   getTodaysHistoryCard: (today: Today) => Promise<curType>;
+  getHistoryPayAmount: () => PriceAmountType;
   initHistoryForToday: () => Promise<curType>;
-  initState: ({ year, month }: Today) => Promise<curType>;
 }
 
 export interface DateState extends State {

--- a/server/api/routes/history.ts
+++ b/server/api/routes/history.ts
@@ -1,13 +1,14 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import historyController from '../../controllers/history.controller';
+import { authMiddleware } from '../middlewares/auth.middleware';
 
 const router = Router();
 
 export default (app: Router) => {
   app.use('/histories', router);
 
-  router.get(`/`, historyController.selectHistory);
-  router.post(`/`, historyController.insertHistory);
-  router.put(`/:historyId`, historyController.updateHistory);
-  router.delete(`/:historyId`, historyController.deleteHistory);
+  router.get(`/`, authMiddleware, historyController.selectHistory);
+  router.post(`/`, authMiddleware, historyController.insertHistory);
+  router.put(`/:historyId`, authMiddleware, historyController.updateHistory);
+  router.delete(`/:historyId`, authMiddleware, historyController.deleteHistory);
 };

--- a/server/controllers/history.controller.ts
+++ b/server/controllers/history.controller.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { Container } from 'typedi';
+import { getPayload } from '../utils/helper';
 import historyServices from './../services/history.services';
 
 const HistoryServices = Container.get(historyServices);
@@ -12,7 +13,7 @@ class HistoryController {
       if (typeof year !== 'string' || typeof month !== 'string')
         throw new Error('year과 month가 유효하지 않습니다.');
 
-      const id: number = req.body.id;
+      const id: number = getPayload(req);
       const historyList = await HistoryServices.selectHistory(id, year, month);
 
       res


### PR DESCRIPTION
- history api routes 에 oauth 로그인 미들웨어 적용
- 서버 history controller 조회 부분만 request의 유저 아이디를 받아오도록 변경 (다른 로직 역시 변경 필요)
- 기존 MainModel => HistoryModel로 수정 및 관련 참조 모두 수정
- 프론트엔드 서버 api history 조회 부분만 구현 후 적용
- 로그인 시 로그인 된 유저 정보로 조회, 비로그인 시 기본유저 정보로 조회하도록 설정