### PR TITLE
[feature] 카테고리/결제수단 중복으로 생성되는 문제 수정

### DIFF
--- a/server/repositories/category.repository.ts
+++ b/server/repositories/category.repository.ts
@@ -61,6 +61,10 @@ export class UserCategoryRepository extends Repository<UserCategory> {
 
 @EntityRepository(Category)
 export class CategoryRepository extends Repository<Category> {
+  findCategoryByType(type: string): Promise<Category | undefined> {
+    return this.findOne({ type });
+  }
+
   createCategoryForUser(type: string): Promise<InsertResult> {
     const result = this.create({ type });
     return this.insert(result);

--- a/server/repositories/category.repository.ts
+++ b/server/repositories/category.repository.ts
@@ -8,7 +8,7 @@ import Category from '../entities/Category';
 import UserCategory from '../entities/UserCategory';
 import { UserCategoryForRemoval, UserCategoryType } from '../types/types';
 
-const category = [
+const defaultCategories = [
   { id: 1, color: '#817DCE' },
   { id: 2, color: '#4A6CC3' },
   { id: 3, color: '#4CA1DE' },
@@ -52,7 +52,7 @@ export class UserCategoryRepository extends Repository<UserCategory> {
 
   insertDefaultCategory(id: number): Promise<InsertResult> {
     return this.insert(
-      category.map((c) => {
+      defaultCategories.map((c) => {
         return { user: { id }, category: { id: c.id }, color: c.color };
       })
     );

--- a/server/repositories/category.repository.ts
+++ b/server/repositories/category.repository.ts
@@ -8,6 +8,16 @@ import Category from '../entities/Category';
 import UserCategory from '../entities/UserCategory';
 import { UserCategoryForRemoval, UserCategoryType } from '../types/types';
 
+const category = [
+  { id: 1, color: '#817DCE' },
+  { id: 2, color: '#4A6CC3' },
+  { id: 3, color: '#4CA1DE' },
+  { id: 4, color: '#94D3CC' },
+  { id: 5, color: '#4CB8B8' },
+  { id: 6, color: '#6ED5EB' },
+  { id: 7, color: '#D092E2' },
+];
+
 @EntityRepository(UserCategory)
 export class UserCategoryRepository extends Repository<UserCategory> {
   findAllByUserId(userId: number): Promise<UserCategory[] | undefined> {
@@ -38,6 +48,14 @@ export class UserCategoryRepository extends Repository<UserCategory> {
     id,
   }: UserCategoryForRemoval): Promise<DeleteResult> {
     return this.delete({ id, user: { id: userId } });
+  }
+
+  insertDefaultCategory(id: number): Promise<InsertResult> {
+    return this.insert(
+      category.map((c) => {
+        return { user: { id }, category: { id: c.id }, color: c.color };
+      })
+    );
   }
 }
 

--- a/server/repositories/payment.repository.ts
+++ b/server/repositories/payment.repository.ts
@@ -49,6 +49,10 @@ export class UserPaymentRepository extends Repository<UserPayment> {
 
 @EntityRepository(Payment)
 export class PaymentRepository extends Repository<Payment> {
+  findPaymentByType(type: string): Promise<Payment | undefined> {
+    return this.findOne({ type });
+  }
+
   createPaymentForUser(type: string): Promise<InsertResult> {
     const result = this.create({ type });
     return this.insert(result);

--- a/server/repositories/payment.repository.ts
+++ b/server/repositories/payment.repository.ts
@@ -8,6 +8,8 @@ import UserPayment from './../entities/UserPayment';
 import Payment from './../entities/Payment';
 import { UserPaymentForRemoval, UserPaymentType } from '../types/types';
 
+const defaultPayments = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
 @EntityRepository(UserPayment)
 export class UserPaymentRepository extends Repository<UserPayment> {
   findAllByUserId(userId: number): Promise<UserPayment[] | undefined> {
@@ -34,6 +36,14 @@ export class UserPaymentRepository extends Repository<UserPayment> {
     id,
   }: UserPaymentForRemoval): Promise<DeleteResult> {
     return this.delete({ id, user: { id: userId } });
+  }
+
+  insertDefaultPayment(id: number): Promise<InsertResult> {
+    return this.insert(
+      defaultPayments.map((p) => {
+        return { user: { id }, payment: { id: p.id } };
+      })
+    );
   }
 }
 

--- a/server/services/category.services.ts
+++ b/server/services/category.services.ts
@@ -25,12 +25,21 @@ export default class CategoryService {
 
   async createCategory({ userId, type, color }: CategoryType) {
     try {
-      const category = await getCustomRepository(
+      const existedCategory = await getCustomRepository(
         CategoryRepository
-      ).createCategoryForUser(type);
-      const {
-        raw: { insertId: categoryId },
-      }: ResultRawType = category;
+      ).findCategoryByType(type);
+
+      // ID가 있는 경우에는 추가하지 않고 해당 카테고리ID로 유저카테고리에 추가
+      let categoryId;
+      if (existedCategory) {
+        categoryId = existedCategory.id;
+      } else {
+        const category = await getCustomRepository(
+          CategoryRepository
+        ).createCategoryForUser(type);
+
+        categoryId = category.raw.insertId.categoryId;
+      }
 
       const result = await getCustomRepository(
         UserCategoryRepository

--- a/server/services/payment.services.ts
+++ b/server/services/payment.services.ts
@@ -25,12 +25,20 @@ export default class PaymentService {
 
   async createPayment({ userId, type }: PaymentType) {
     try {
-      const payment = await getCustomRepository(
+      const existedPayment = await getCustomRepository(
         PaymentRepository
-      ).createPaymentForUser(type);
-      const {
-        raw: { insertId: paymentId },
-      }: ResultRawType = payment;
+      ).findPaymentByType(type);
+
+      // ID가 있는 경우에는 추가하지 않고 해당 페이먼트ID로 유저페이먼트에 추가
+      let paymentId;
+      if (existedPayment) {
+        paymentId = existedPayment.id;
+      } else {
+        const category = await getCustomRepository(
+          PaymentRepository
+        ).createPaymentForUser(type);
+        paymentId = category.raw.insertId.paymentId;
+      }
 
       const result = await getCustomRepository(
         UserPaymentRepository

--- a/server/services/user.services.ts
+++ b/server/services/user.services.ts
@@ -6,6 +6,7 @@ import { UserProfile } from '../types/types';
 import User from '../entities/User';
 import { Service } from 'typedi';
 import { extractInsertId } from '../utils/helper';
+import { UserCategoryRepository } from '../repositories/category.repository';
 
 @Service()
 export default class UserService {
@@ -31,6 +32,17 @@ export default class UserService {
     }
   }
 
+  async insertDefaultCategory(userId: number): Promise<InsertResult> {
+    try {
+      const res = await getCustomRepository(
+        UserCategoryRepository
+      ).insertDefaultCategory(userId);
+      return res;
+    } catch (error) {
+      throw new Error('[User 쿼리오류]' + error);
+    }
+  }
+
   async checkUserAlreadyExist(
     userProfile: UserProfile,
     user: User | undefined
@@ -41,6 +53,7 @@ export default class UserService {
       if (!user) {
         const result = await this.createUserByGithubUser(userProfile.login);
         userId = extractInsertId(result);
+        await this.insertDefaultCategory(userId);
       } else {
         userId = user.id;
       }

--- a/server/services/user.services.ts
+++ b/server/services/user.services.ts
@@ -7,6 +7,7 @@ import User from '../entities/User';
 import { Service } from 'typedi';
 import { extractInsertId } from '../utils/helper';
 import { UserCategoryRepository } from '../repositories/category.repository';
+import { UserPaymentRepository } from '../repositories/payment.repository';
 
 @Service()
 export default class UserService {
@@ -43,6 +44,17 @@ export default class UserService {
     }
   }
 
+  async insertDefaultPayment(userId: number): Promise<InsertResult> {
+    try {
+      const res = await getCustomRepository(
+        UserPaymentRepository
+      ).insertDefaultPayment(userId);
+      return res;
+    } catch (error) {
+      throw new Error('[User 쿼리오류]' + error);
+    }
+  }
+
   async checkUserAlreadyExist(
     userProfile: UserProfile,
     user: User | undefined
@@ -54,6 +66,7 @@ export default class UserService {
         const result = await this.createUserByGithubUser(userProfile.login);
         userId = extractInsertId(result);
         await this.insertDefaultCategory(userId);
+        await this.insertDefaultPayment(userId);
       } else {
         userId = user.id;
       }


### PR DESCRIPTION
관련 이슈 : #68 

* 카테고리/결제수단의 타입이 같은데도 중복되어 생성되는 문제 수정했습니다.
* 카테고리를 삭제했을 때 히스토리의 tag color는 따로 브랜치 생성하여 PR 하겠습니다.

### 주의(?)라고 해야 할 점
카테고리와 결제 수단의 디폴트를 각 테이블의 `1 ~ 7`, `1 ~ 3`으로 지정하였습니다.   
클라이언트에서 카테고리 수정은 안되지만 직접 DB를 조작할 때 수정되지 않게 주의해주세용

> category table
<img src="https://user-images.githubusercontent.com/49540564/128004735-e98263df-f4a7-49b5-862b-1e07194e9d50.png" width=250/>

> payment table
<img src="https://user-images.githubusercontent.com/49540564/128004790-4ac72e62-ab35-47c9-aa8f-7451780a6a15.png" width=250/>

