### PR TITLE
[feature] 도넛 차트 API 연동 및 애니메이션 작성 + 라인 차트 기본 구독 모델 설정

### DIFF
--- a/client/src/Components/DonutChart/styles.scss
+++ b/client/src/Components/DonutChart/styles.scss
@@ -1,11 +1,16 @@
 @import '@/scss/theme';
 
-.chart-view {
-  circle {
-    cursor: pointer;
-    &:hover {
-      opacity: 0.75;
-      // transform: scale(1.1);
+#donut-chart {
+  .svg-text {
+    &.income {
+      stroke: $primary3 !important;
     }
+
+    &.outcome {
+      stroke: $red !important;
+    }
+  }
+  circle {
+    filter: drop-shadow(3px 3px 2px rgba(0, 0, 0, 0.1));
   }
 }

--- a/client/src/Components/HistoryCategoryCard/styles.scss
+++ b/client/src/Components/HistoryCategoryCard/styles.scss
@@ -7,11 +7,22 @@
   .button-area {
     display: flex;
     justify-content: flex-end;
+    float: right;
     gap: 1rem;
     @include body-medium;
 
-    div {
+    .button {
       cursor: pointer;
+      padding: 1rem 2rem;
+      border-radius: 0.5rem;
+
+      &.active {
+        background-color: $primary1;
+        color: $white;
+      }
+      &:hover {
+        opacity: 0.75;
+      }
     }
   }
 
@@ -19,15 +30,20 @@
     margin-top: 2rem;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
 
     .category-card {
       display: flex;
-      gap: 1rem;
+      gap: 1.5rem;
       justify-content: space-between;
       align-items: center;
-      padding-bottom: 1rem;
+      padding-top: 1.5rem;
+      padding-bottom: 1.5rem;
       border-bottom: 0.1rem solid $line;
+      cursor: pointer;
+
+      &:hover {
+        background-color: $backgrond;
+      }
 
       .percent {
         @include body-medium;

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -1,0 +1,57 @@
+import Component from '@/Core/Component';
+import './styles';
+import { html, asyncSetState } from '@/utils/helper';
+import {
+  ChartControllerType,
+  HistoryModelType,
+  IHistory,
+  Props,
+  State,
+  Today,
+  TodayModelType,
+} from '@/utils/types';
+import HistoryModel from '@/Model/HistoryModel';
+import ChartController from '@/Controller/ChartController';
+import DateModel from '@/Model/DateModel';
+
+interface IListStates extends State {
+  today: Today;
+  selectedCategory: string;
+  selectedHistoryForCategory: IHistory[];
+}
+
+export default class LineChart extends Component<IListStates, Props> {
+  historyModel!: HistoryModelType;
+  dateModel!: TodayModelType;
+  chartController!: ChartControllerType;
+
+  setup() {
+    this.classIDF = 'LineChart';
+
+    this.historyModel = HistoryModel;
+    this.historyModel.subscribe(this.historyModel.key, this);
+    this.chartController = ChartController;
+
+    this.dateModel = DateModel;
+    this.dateModel.subscribe(this.dateModel.key, this);
+
+    this.$state = {
+      selectedHistoryForCategory: [],
+      selectedCategory: '',
+      today: this.dateModel.today,
+    };
+
+    asyncSetState(this.historyModel.getHistoryCard(this.$state.today));
+  }
+
+  template() {
+    const { selectedCategory, selectedHistoryForCategory } = this.$state!;
+    console.log(selectedCategory, selectedHistoryForCategory);
+    return html` <div>안녕하세욥! 라인 차트에용</div> `;
+  }
+
+  setUnmount() {
+    this.historyModel.unsubscribe(this.historyModel.key, this);
+    this.dateModel.unsubscribe(this.dateModel.key, this);
+  }
+}

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -1,0 +1,1 @@
+@import '@/scss/theme';

--- a/client/src/Controller/ChartController.ts
+++ b/client/src/Controller/ChartController.ts
@@ -1,0 +1,125 @@
+import { CategoryCardsType, HistoryModelType, IHistory } from '@/utils/types';
+import HistoryModel from '@/Model/HistoryModel';
+import { asyncSetState } from '@/utils/helper';
+
+const PERCENTAGE = 100;
+const CIRCLEDEGREE = 360;
+
+class ChartController {
+  historyModel!: HistoryModelType;
+
+  constructor() {
+    this.historyModel = HistoryModel;
+  }
+
+  filterHistoryCardByCategory(historyCards: IHistory[], type: number) {
+    const typedHistoryCards = historyCards.filter(
+      (history) => history.type === type
+    );
+
+    const priceAmount = typedHistoryCards.reduce((acc, cur) => {
+      return acc + Number(cur.price);
+    }, 0);
+
+    const categoryCards = typedHistoryCards.reduce(
+      (acc: CategoryCardsType, history) => {
+        if (!acc[history.category]) {
+          acc[history.category] = { price: 0, percent: 0 };
+          acc[history.category].price += +history.price;
+          return acc;
+        }
+
+        acc[history.category].price += +history.price;
+        return acc;
+      },
+      {}
+    );
+
+    Object.entries(categoryCards).forEach((card) => {
+      const [key, value] = card;
+      categoryCards[key].percent = Math.round(
+        (value.price / priceAmount) * 100
+      );
+    });
+
+    const categories = Object.entries(categoryCards)
+      .map((card) => card)
+      .sort((a, b) => b[1].percent - a[1].percent)
+      .map((card) => card[0]);
+
+    return { categories, categoryCards };
+  }
+
+  filterHistoryCardBySelectedCategory(
+    historyCards: IHistory[],
+    type: number,
+    selectedCategory: string
+  ) {
+    const typedHistoryCards = historyCards.filter(
+      (history) =>
+        history.type === type && history.category === selectedCategory
+    );
+
+    asyncSetState(
+      this.historyModel.getHistoryCardForCategory(
+        selectedCategory,
+        typedHistoryCards
+      )
+    );
+  }
+
+  makeDonutChart(
+    categories: string[],
+    categoryCards: CategoryCardsType,
+    $svg: HTMLElement
+  ) {
+    let totalPercentage = 0;
+    const startAngle = -90;
+    const radius = 30;
+    const cx = 50,
+      cy = 50;
+    const strokeWidth = 15;
+    const dashArray = 2 * Math.PI * radius;
+    const speedMs = 650;
+
+    categories.forEach((category) => {
+      const circle = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'circle'
+      );
+
+      const dashOffset =
+        dashArray - (dashArray * categoryCards[category].percent) / PERCENTAGE;
+      const currentDuration =
+        (speedMs * categoryCards[category].percent) / PERCENTAGE;
+      const delay = (speedMs * totalPercentage) / PERCENTAGE;
+      const angle = (totalPercentage * CIRCLEDEGREE) / PERCENTAGE + startAngle;
+
+      circle.setAttribute('r', radius.toString());
+      circle.setAttribute('cx', cx.toString());
+      circle.setAttribute('cy', cy.toString());
+      circle.setAttribute('fill', 'transparent');
+      circle.setAttribute(
+        'stroke',
+        '#' + Math.round(Math.random() * 0xfff).toString(16)
+        // 색깔 카테고리에서 받아와야 함!!
+      );
+      circle.setAttribute('stroke-width', strokeWidth.toString());
+      circle.setAttribute('stroke-dasharray', dashArray.toString());
+      circle.setAttribute('stroke-dashoffset', dashArray.toString());
+      circle.style.transition =
+        'stroke-dashoffset ' + currentDuration + 'ms linear ' + delay + 'ms';
+      circle.setAttribute(
+        'transform',
+        'rotate(' + angle + ' ' + cx + ' ' + cy + ')'
+      );
+      $svg?.append(circle);
+      totalPercentage += categoryCards[category].percent;
+      setTimeout(function () {
+        circle.setAttribute('stroke-dashoffset', dashOffset.toString());
+      }, 100);
+    });
+  }
+}
+
+export default new ChartController();

--- a/client/src/Core/Component.ts
+++ b/client/src/Core/Component.ts
@@ -66,6 +66,9 @@ export default class Component<S extends State, P extends Props> {
   }
 
   setState(nextState: S) {
+    const next = { ...this.$state, ...nextState };
+    if (JSON.stringify(next) === JSON.stringify(this.$state)) return;
+
     this.$state = { ...this.$state, ...nextState };
     this.render();
   }

--- a/client/src/Model/HistoryModel.ts
+++ b/client/src/Model/HistoryModel.ts
@@ -11,12 +11,18 @@ import {
 } from '@/utils/types';
 import dayjs from 'dayjs';
 
+const INCOME = 1;
+const EXPENSE = 0;
+
 class HistoryModel extends Observable {
   key: string = 'history';
   historyCards: IHistory[];
   historyType: HistoryType;
   priceAmount: PriceAmountType;
   historyCardForToday: IHistory[];
+  selectedType: number;
+  selectedCategory: string;
+  selectedHistoryForCategory: IHistory[];
 
   constructor() {
     super();
@@ -31,6 +37,9 @@ class HistoryModel extends Observable {
       outcome: 0,
     };
     this.historyCardForToday = [];
+    this.selectedType = EXPENSE;
+    this.selectedCategory = '';
+    this.selectedHistoryForCategory = [];
   }
 
   async getHistoryCard(today: Today) {
@@ -39,6 +48,18 @@ class HistoryModel extends Observable {
     const { historyList } = data;
     this.historyCards = historyList;
     return this.notify(this.key, { historyCards: historyList });
+  }
+
+  getHistoryCardForCategory(
+    selectedCategory: string,
+    selectedHistoryForCategory: IHistory[]
+  ) {
+    this.selectedCategory = selectedCategory;
+    this.selectedHistoryForCategory = selectedHistoryForCategory;
+    return this.notify(this.key, {
+      selectedCategory: this.selectedCategory,
+      selectedHistoryForCategory: this.selectedHistoryForCategory,
+    });
   }
 
   getTodaysHistoryCard(today: Today) {
@@ -71,25 +92,9 @@ class HistoryModel extends Observable {
     return this.notify(this.key, { historyType: this.historyType });
   }
 
-  private filterHistoryCardsByMonth(today: Today): void {
-    this.historyCards = dummyhistories
-      .filter((history) => {
-        const [year, month, _] = history.createdAt
-          .split('-')
-          .map((d) => parseInt(d));
-        return today.year === year && today.month === month;
-      })
-      .map((history) => {
-        return {
-          createdAt: history.createdAt,
-          type: history.type,
-          category: history.category,
-          content: history.content,
-          payment: history.payment,
-          price: history.price,
-          id: history.id,
-        };
-      });
+  toggleSelectedType(type: number) {
+    this.selectedType = type;
+    return this.notify(this.key, { selectedType: this.selectedType });
   }
 
   private filterHistoryPriceAmount() {

--- a/client/src/View/ChartsView/index.ts
+++ b/client/src/View/ChartsView/index.ts
@@ -3,7 +3,8 @@ import Component from '@/Core/Component';
 import { html } from '@/utils/helper';
 import { Props, State } from '@/utils/types';
 import DonutChart from '@/Components/DonutChart';
-import HistoryCategoryCard from './../../Components/HistoryCategoryCard/index';
+import HistoryCategoryCard from '@/Components/HistoryCategoryCard/index';
+import LineChart from '@/Components/LineChart/index';
 
 export default class ChartsView extends Component<State, Props> {
   template() {
@@ -27,10 +28,15 @@ export default class ChartsView extends Component<State, Props> {
   }
 
   mounted() {
-    const $chart = this.$target.querySelector(
+    const $donutChart = this.$target.querySelector(
       '.donut-chart-view'
     ) as HTMLElement;
-    new DonutChart($chart);
+    new DonutChart($donutChart);
+
+    const $lineChart = this.$target.querySelector(
+      '.line-chart-view'
+    ) as HTMLElement;
+    new LineChart($lineChart);
 
     const $historyCategoryList = this.$target.querySelector(
       '.history-category-list-wrapper'

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -85,10 +85,18 @@ export interface HistoryModelType extends Model {
   historyCards: IHistory[];
   historyType: HistoryType;
   historyCardForToday: IHistory[];
+  selectedType: number;
+  selectedCategory: string;
+  selectedHistoryForCategory: IHistory[];
   getHistoryCard: ({ year, month }: Today) => Promise<curType>;
   addHistory: (history: IHistory) => Promise<curType>;
   toggleType: (nextType: typeString) => Promise<curType>;
+  toggleSelectedType: (type: number) => Promise<curType>;
   getTodaysHistoryCard: (today: Today) => Promise<curType>;
+  getHistoryCardForCategory: (
+    selectedCategory: string,
+    selectedHistories: IHistory[]
+  ) => Promise<curType>;
   getHistoryPayAmount: () => PriceAmountType;
   initHistoryForToday: () => Promise<curType>;
 }
@@ -230,4 +238,32 @@ export type CategoryType = {
   id: number;
   type: string;
   color: string;
+};
+
+/**
+ * @example
+ * ChartController 데이터 관련 타입
+ */
+export type CategoryCardsType = {
+  [key: string]: {
+    price: number;
+    percent: number;
+  };
+};
+
+export type ChartControllerType = {
+  filterHistoryCardByCategory: (
+    historyCards: IHistory[],
+    type: number
+  ) => { categories: string[]; categoryCards: CategoryCardsType };
+  filterHistoryCardBySelectedCategory: (
+    historyCards: IHistory[],
+    type: number,
+    selectedCategory: string
+  ) => void;
+  makeDonutChart: (
+    categories: string[],
+    categoryCards: CategoryCardsType,
+    $svg: HTMLElement
+  ) => void;
 };


### PR DESCRIPTION
관련이슈 : #6 #7 #8 

- 도넛 차트 퍼센테이지 비율로 출력 및 애니메이션 부여
- 라인 차트 컴포넌트에 선택된 카테고리 및 카테고리 히스토리 정보 전달하도록 구독 모델 설정
- 차트 컨트롤러 필요한 로직 분리하여 작성
- 리렌더링 시 동일 값이면 렌더하지 않도록 설정
