### PR TITLE
[bugfix] 도넛 차트 퍼센트 계산 문제 수정

### DIFF
--- a/client/src/Components/DonutChart/index.ts
+++ b/client/src/Components/DonutChart/index.ts
@@ -17,25 +17,6 @@ import HistoryModel from '@/Model/HistoryModel';
 import DateModel from '@/Model/DateModel';
 import CategoryModel from '@/Model/CategoryModel';
 
-const data = [
-  {
-    percent: 15,
-    color: '#80e080',
-  },
-  {
-    percent: 35,
-    color: '#4fc3f7',
-  },
-  {
-    percent: 20,
-    color: '#9575cd',
-  },
-  {
-    percent: 30,
-    color: '#f06292',
-  },
-];
-
 interface IListStates extends State {
   historyCards: IHistory[];
   today: Today;

--- a/client/src/Components/DropDown/index.ts
+++ b/client/src/Components/DropDown/index.ts
@@ -43,18 +43,15 @@ export default class DropDown extends Component<DropDownState, Props> {
   }
 
   setEvent() {
-    console.log(this.$state);
     this.addEvent('click', '.drop-down', this.$state!.handler);
+    this.addEvent('click', '.drop-down', this.toggleDropdown.bind(this));
+  }
 
-    document.addEventListener('click', (e: MouseEvent) => {
-      const isDropDownClicked = (<HTMLElement>e.target).closest('.drop-down');
-      if (!isDropDownClicked) {
-        const dropdown = (<HTMLUListElement>(
-          document.querySelector('.drop-down')
-        )) as HTMLUListElement;
-        dropdown.style.display = 'none';
-        dropdown.style.opacity = '0';
-      }
-    });
+  toggleDropdown() {
+    const dropdown = (<HTMLUListElement>(
+      document.querySelector('.drop-down')
+    )) as HTMLUListElement;
+    dropdown.style.display = 'none';
+    dropdown.style.opacity = '0';
   }
 }

--- a/client/src/Components/HistoryCategoryCard/index.ts
+++ b/client/src/Components/HistoryCategoryCard/index.ts
@@ -100,8 +100,10 @@ export default class HistoryCategoryCard extends Component<IListStates, Props> {
             <li class="category-card" data-category="${category.type}">
               <span class="category">${CategoryTag(category)}</span>
               <span class="percent">${
-                categoryCards[category.type].percent
-              }%</span>
+                Math.round(categoryCards[category.type].percent) === 0
+                  ? '1% 이하'
+                  : Math.round(categoryCards[category.type].percent) + '%'
+              }</span>
               <span class="price">${addComma(
                 categoryCards[category.type].price + ''
               )}</span>
@@ -110,6 +112,7 @@ export default class HistoryCategoryCard extends Component<IListStates, Props> {
             )
             .join('')}
         </ul>
+        <p class="warning-text">오차범위: ± 0.5%</p>
       </div>
     `;
   }
@@ -141,5 +144,6 @@ export default class HistoryCategoryCard extends Component<IListStates, Props> {
   setUnmount() {
     this.historyModel.unsubscribe(this.historyModel.key, this);
     this.categoryModel.unsubscribe(this.categoryModel.key, this);
+    this.dateModel.unsubscribe(this.dateModel.key, this);
   }
 }

--- a/client/src/Components/HistoryCategoryCard/styles.scss
+++ b/client/src/Components/HistoryCategoryCard/styles.scss
@@ -1,4 +1,5 @@
 @import '@/scss/theme';
+@import '@/scss/animation';
 
 .category-percentage {
   display: flex;
@@ -15,11 +16,25 @@
       cursor: pointer;
       padding: 1rem 2rem;
       border-radius: 0.5rem;
+      transition: all 0.2s ease-in;
 
-      &.active {
-        background-color: $primary1;
-        color: $white;
+      &#income {
+        color: $primary3;
+        border: 0.1rem solid $primary3;
+        &.active {
+          background-color: $primary3;
+          color: $white;
+        }
       }
+      &#outcome {
+        color: $red;
+        border: 0.1rem solid $red;
+        &.active {
+          background-color: $red;
+          color: $white;
+        }
+      }
+
       &:hover {
         opacity: 0.75;
       }
@@ -40,6 +55,7 @@
       padding-bottom: 1.5rem;
       border-bottom: 0.1rem solid $line;
       cursor: pointer;
+      animation: fadein 1s forwards;
 
       &:hover {
         background-color: $backgrond;
@@ -57,5 +73,12 @@
         color: $title-active;
       }
     }
+  }
+
+  .warning-text {
+    color: $red;
+    text-align: right;
+    margin-top: 1rem;
+    @include bold-small;
   }
 }

--- a/client/src/Controller/ChartController.ts
+++ b/client/src/Controller/ChartController.ts
@@ -43,9 +43,7 @@ class ChartController {
 
     Object.entries(categoryCards).forEach((card) => {
       const [key, value] = card;
-      categoryCards[key].percent = Math.round(
-        (value.price / priceAmount) * 100
-      );
+      categoryCards[key].percent = (value.price / priceAmount) * 100;
     });
 
     const categories = Object.entries(categoryCards)

--- a/client/src/scss/animation.scss
+++ b/client/src/scss/animation.scss
@@ -1,0 +1,10 @@
+@keyframes fadein {
+  from {
+    transform: translateY(50%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
관련이슈: #80  #88 

- 퍼센트 계산이 100%를 넘어가는 경우를 수정했습니다.
- 퍼센트 중에 반올림으로 인해 0%가 출력되는 문제를 수정했습니다.
- 도넛 차트 우측 카테고리 리스트 출력에 애니메이션 효과를 부여했습니다.
- Dropdown 컴포넌트의 전역 이벤트 핸들러 설정으로 인한 중복 해결했습니다.