### PR TITLE
[feature] line chart 마크업 및 API 연동

### DIFF
--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -133,10 +133,15 @@ export default class LineChart extends Component<IListStates, Props> {
     const xSection = this.getXSection(dataPoint); // month section
     const pointCircle = this.getPointCircle(dataPoint, color); // point
     const expenseText = this.getExpenseText(dataPoint, statList); // 금액
+    const todayLine = this.getTodayLine(
+      dataPoint[this.$state!.today.month - 1],
+      color
+    );
     const sectionPointGroup = this.makeSectionPointGroup(
       xSection,
       pointCircle,
-      expenseText
+      expenseText,
+      todayLine
     );
     const defsElem = this.getDefs(color);
     [standYLine, YGroup, XGroup, chart, ...sectionPointGroup, defsElem].forEach(
@@ -280,7 +285,6 @@ export default class LineChart extends Component<IListStates, Props> {
     const maxBoundExpense = Math.round(maxExpense / div) * div;
     const intervalExpense = maxBoundExpense / magicNumber.numY;
     const intervalY = this.chartInfo.maxValue / magicNumber.numY;
-    console.log(maxExpense, div, maxBoundExpense, intervalExpense, intervalY);
 
     const standExpenseList = [];
     for (let i = 0; i <= magicNumber.numY; i++) {
@@ -354,6 +358,7 @@ export default class LineChart extends Component<IListStates, Props> {
   getPointCircle(dataPoint: Point[], color: string) {
     const pointList: SVGCircleElement[] = [];
 
+    console.log(dataPoint);
     dataPoint.forEach((data, idx) => {
       const $circle = document.createElementNS(
         'http://www.w3.org/2000/svg',
@@ -376,15 +381,24 @@ export default class LineChart extends Component<IListStates, Props> {
   makeSectionPointGroup(
     xSection: SVGPathElement[],
     pointCircle: SVGCircleElement[],
-    expenseText: SVGTextElement[]
+    expenseText: SVGTextElement[],
+    todayLine: SVGPathElement
   ) {
+    const { month } = this.$state!.today;
     const groupList: SVGGElement[] = [];
     xSection.forEach((section, idx) => {
       const $group = document.createElementNS(
         'http://www.w3.org/2000/svg',
         'g'
       );
-      $group.setAttribute('class', 'section-point-group');
+
+      if (idx + 1 === month) {
+        $group.setAttribute(
+          'class',
+          'section-point-group line-chart-today-line'
+        );
+        $group.append(todayLine);
+      } else $group.setAttribute('class', 'section-point-group');
       $group.dataset.id = `${idx + 1}`;
       $group.appendChild(section);
       $group.appendChild(pointCircle[idx]);
@@ -394,6 +408,26 @@ export default class LineChart extends Component<IListStates, Props> {
     });
 
     return groupList;
+  }
+
+  getTodayLine(point: Point, color: string) {
+    const halfInterval = this.chartInfo.intervalX / 2;
+    const todayLine = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'path'
+    );
+    console.log(point);
+
+    const d = `
+      M ${point[0]},${magicNumber.CHART_BOTTOM}
+      L ${point[0]},${point[1]}
+    `;
+    todayLine.setAttribute('d', d);
+    todayLine.setAttribute('stroke', color);
+    todayLine.setAttribute('stroke-width', '3');
+    todayLine.setAttribute('style', 'transform: scale(1, -1);');
+
+    return todayLine;
   }
 
   getDefs(color: string) {

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -22,15 +22,31 @@ interface IListStates extends State {
   selectedCategory: string;
   selectedHistoryForCategory: IHistory[];
   categoryList: CategoryType[];
+  statList?: number[];
 }
+
+type Point = number[];
+
+const magicNumber = {
+  WIDTH: 1920,
+  HEIGHT: 700,
+  CHART_TOP: 100,
+  CHART_LEFT: 100,
+  CHART_BOTTOM: 0,
+  CHART_RIGHT: 100,
+};
 
 export default class LineChart extends Component<IListStates, Props> {
   historyModel!: HistoryModelType;
   dateModel!: TodayModelType;
   chartController!: ChartControllerType;
   categoryModel!: CategoryModelType;
+  chartInfo!: {
+    intervalX: number;
+    maxValue: number;
+  };
 
-  setup() {
+  async setup() {
     this.classIDF = 'LineChart';
 
     this.historyModel = HistoryModel;
@@ -52,17 +68,225 @@ export default class LineChart extends Component<IListStates, Props> {
 
     asyncSetState(this.historyModel.getHistoryCard(this.$state.today));
     asyncSetState(this.categoryModel.getUserCategories());
+    asyncSetState(this.historyModel.getAverageByMonth(2021, '식비'));
   }
 
   template() {
-    const { selectedCategory, selectedHistoryForCategory } = this.$state!;
-    console.log(selectedCategory, selectedHistoryForCategory);
-    return html` <div>안녕하세욥! 라인 차트에용</div> `;
+    return html`
+      <svg
+        version="1.1"
+        id="line-chart"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        x="0px"
+        y="0px"
+        viewBox="0 ${-magicNumber.HEIGHT} ${magicNumber.WIDTH} ${magicNumber.HEIGHT}"
+        style="enable-background:new 0 0 ${magicNumber.WIDTH} ${magicNumber.HEIGHT};"
+        xml:space="preserve"
+      ></svg>
+    `;
+  }
+
+  mounted() {
+    const svg = this.$target.querySelector('#line-chart') as SVGElement;
+    if (this.$state?.statList) {
+      const dataPoint = this.getPoints(this.$state?.statList);
+
+      const chart = this.getLineChartPath(dataPoint); // line graph
+      const standYLine = this.getStandYLine(); // y축 가로선
+      const xSection = this.getXSection(dataPoint); // month section
+      const pointCircle = this.getPointCircle(dataPoint);
+      const sectionPointGroup = this.makeSectionPointGroup(
+        xSection,
+        pointCircle
+      );
+      svg.appendChild(standYLine);
+      svg.appendChild(chart);
+      sectionPointGroup.forEach((group) => svg.appendChild(group));
+    }
+  }
+
+  // 곡선 그래프
+  getLineChartPath(dataPoint: Point[]) {
+    const $path = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'path'
+    );
+    $path.setAttribute('d', this.getPathAttribute(dataPoint));
+    // $path.setAttribute('d', this.getLine(dataPoint));
+    $path.setAttribute('fill', '#5758bb');
+    $path.setAttribute('stroke', '#143794');
+    $path.setAttribute('stroke-width', '4');
+    $path.setAttribute('style', 'transform: scale(1, -1)');
+
+    return $path;
+  }
+
+  getPoints(data: number[]): Point[] {
+    const [graphWidth, graphHeight] = [
+      magicNumber.WIDTH - (magicNumber.CHART_LEFT + magicNumber.CHART_RIGHT),
+      magicNumber.HEIGHT - (magicNumber.CHART_TOP + magicNumber.CHART_BOTTOM),
+    ];
+    const intervalX = graphWidth / (data.length - 1);
+    const max = Math.round((Math.max(...data) + 100000) / 10) * 10;
+
+    this.chartInfo = {
+      intervalX: intervalX,
+      maxValue: graphHeight,
+    };
+
+    return data.reduce((acc: Point[], cur: number, i) => {
+      const point: Point = [
+        intervalX * i + magicNumber.CHART_LEFT,
+        (cur / max) * graphHeight,
+      ];
+      return [...acc, point];
+    }, []);
+  }
+
+  /**
+   *
+   * @param points Point List
+   * @returns Point로 만든 Path Attribute
+   */
+  getPathAttribute(points: Point[]): string {
+    const pointLine = points.reduce((acc, point, i, a) => {
+      if (i === 0) return `M ${point[0]},${point[1]}`;
+
+      // start control point
+      const [cpsX, cpsY] = this.getControlPoint(a[i - 1]);
+      // end control point
+      const [cpeX, cpeY] = this.getControlPoint(point, true);
+
+      return `${acc} C ${cpsX},${cpsY} ${cpeX},${cpeY} ${point[0]},${point[1]}`;
+    }, '');
+
+    return [
+      pointLine,
+      `L ${points[points.length - 1][0]}, ${0}`,
+      `L ${points[0][0]}, ${0}`,
+      `L ${points[0][0]}, ${points[0][1]}`,
+    ].join('');
   }
 
   setUnmount() {
     this.historyModel.unsubscribe(this.historyModel.key, this);
     this.dateModel.unsubscribe(this.dateModel.key, this);
     this.categoryModel.unsubscribe(this.categoryModel.key, this);
+  }
+
+  getControlPoint(current: Point, reverse: boolean = false): Point {
+    const angle = reverse ? Math.PI : 0;
+    const interval = Math.floor(magicNumber.WIDTH / (30 - 1));
+    const length = interval;
+
+    const x = current[0] + Math.cos(angle) * length;
+    const y = current[1] + Math.sin(angle) * length;
+    return [x, y];
+  }
+
+  // 그래프의 가로 선
+  getStandYLine() {
+    const $path = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'path'
+    );
+    $path.setAttribute('d', this.getStandLineAttribute());
+    $path.setAttribute('fill', 'none');
+    $path.setAttribute('stroke', '#d2d2d2');
+    $path.setAttribute('stroke-width', '2');
+    $path.setAttribute('style', 'transform: scale(1, -1)');
+
+    return $path;
+  }
+
+  getStandLineAttribute() {
+    const numY = 6;
+    const intervalY = this.chartInfo.maxValue / numY;
+    const lineY = [];
+    for (let i = 0; i < numY + 1; i++) {
+      lineY.push(intervalY * i);
+    }
+    return lineY.map((y) => `M ${0},${y} L ${magicNumber.WIDTH},${y}`).join('');
+  }
+
+  // 마우스 hover시 나타나는 section
+  getXSection(dataPoint: Point[]) {
+    const sections: SVGPathElement[] = [];
+    const sectionPathList = this.getXSectionAttribute(dataPoint);
+    sectionPathList.forEach((sectionPath) => {
+      const $path = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path'
+      );
+      $path.setAttribute('d', sectionPath);
+      $path.setAttribute('class', 'month-section');
+      $path.setAttribute('style', 'transform: scale(1, -1);');
+
+      sections.push($path);
+    });
+
+    return sections;
+  }
+
+  getXSectionAttribute(dataPoint: Point[]) {
+    const halfInterval = this.chartInfo.intervalX / 2;
+
+    return dataPoint.map((data, i) => {
+      const left = data[0] - halfInterval;
+      const right = data[0] + halfInterval;
+
+      return `      
+      M ${left},${0}
+      L ${right}, ${0}
+      L ${right}, ${this.chartInfo.maxValue}
+      L ${left}, ${this.chartInfo.maxValue}
+      L ${left}, ${0}
+    `;
+    });
+  }
+
+  getPointCircle(dataPoint: Point[]) {
+    const pointList: SVGCircleElement[] = [];
+
+    dataPoint.forEach((data, idx) => {
+      const $circle = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'circle'
+      );
+
+      $circle.setAttribute('cx', `${data[0]}`);
+      $circle.setAttribute('cy', `${data[1]}`);
+      $circle.setAttribute('r', `${10}`);
+      $circle.setAttribute('class', 'month-point');
+      $circle.dataset.id = `${idx}`;
+      $circle.setAttribute('style', 'transform: scale(1, -1);');
+
+      pointList.push($circle);
+    });
+
+    return pointList;
+  }
+
+  makeSectionPointGroup(
+    xSection: SVGPathElement[],
+    pointCircle: SVGCircleElement[]
+  ) {
+    const groupList: SVGGElement[] = [];
+    xSection.forEach((section, idx) => {
+      const $group = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'g'
+      );
+
+      $group.setAttribute('class', 'section-point-group');
+      $group.dataset.id = `${idx}`;
+      $group.appendChild(section);
+      $group.appendChild(pointCircle[idx]);
+
+      groupList.push($group);
+    });
+
+    return groupList;
   }
 }

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -32,9 +32,9 @@ type Point = number[];
 const magicNumber = {
   WIDTH: 1920,
   HEIGHT: 700,
-  CHART_TOP: 100,
-  CHART_LEFT: 200,
-  CHART_BOTTOM: 0,
+  CHART_TOP: 0,
+  CHART_LEFT: 220,
+  CHART_BOTTOM: 100,
   CHART_RIGHT: 100,
   numY: 5,
 };
@@ -168,14 +168,15 @@ export default class LineChart extends Component<IListStates, Props> {
 
     this.chartInfo = {
       intervalX: intervalX,
-      maxValue: graphHeight,
+      maxValue:
+        graphHeight - (magicNumber.CHART_BOTTOM + magicNumber.CHART_TOP),
       maxExpense: max,
     };
 
     return data.reduce((acc: Point[], cur: number, i) => {
       const point: Point = [
         intervalX * i + magicNumber.CHART_LEFT,
-        (cur / max) * graphHeight,
+        (cur / max) * this.chartInfo.maxValue + magicNumber.CHART_BOTTOM,
       ];
       return [...acc, point];
     }, []);
@@ -200,8 +201,8 @@ export default class LineChart extends Component<IListStates, Props> {
 
     return [
       pointLine,
-      `L ${points[points.length - 1][0]}, ${0}`,
-      `L ${points[0][0]}, ${0}`,
+      `L ${points[points.length - 1][0]}, ${magicNumber.CHART_BOTTOM}`,
+      `L ${points[0][0]}, ${magicNumber.CHART_BOTTOM}`,
       `L ${points[0][0]}, ${points[0][1]}`,
     ].join('');
   }
@@ -238,6 +239,7 @@ export default class LineChart extends Component<IListStates, Props> {
       'http://www.w3.org/2000/svg',
       'g'
     );
+    $textGroup.setAttribute('class', 'line-chart-stand-text');
     this.getStandText().forEach((text) => {
       $textGroup.appendChild(text);
     });
@@ -249,7 +251,7 @@ export default class LineChart extends Component<IListStates, Props> {
     const intervalY = this.chartInfo.maxValue / magicNumber.numY;
     const lineY = [];
     for (let i = 0; i < magicNumber.numY + 1; i++) {
-      lineY.push(intervalY * i);
+      lineY.push(intervalY * i + magicNumber.CHART_BOTTOM);
     }
     return lineY
       .map(
@@ -270,9 +272,8 @@ export default class LineChart extends Component<IListStates, Props> {
         'http://www.w3.org/2000/svg',
         'text'
       );
-      text.setAttribute('class', 'line-chart-stand-text');
-      text.setAttribute('x', `${10}`);
-      text.setAttribute('y', `${-intervalY * i}`);
+      text.setAttribute('x', `${magicNumber.CHART_LEFT / 2}`);
+      text.setAttribute('y', `${-(intervalY * i + magicNumber.CHART_BOTTOM)}`);
       text.innerHTML = addComma(`${intervalExpense * i}`);
       standExpenseList.push(text);
     }
@@ -306,11 +307,11 @@ export default class LineChart extends Component<IListStates, Props> {
       const right = data[0] + halfInterval;
 
       return `      
-      M ${left},${0}
-      L ${right}, ${0}
-      L ${right}, ${this.chartInfo.maxValue}
-      L ${left}, ${this.chartInfo.maxValue}
-      L ${left}, ${0}
+      M ${left},${magicNumber.CHART_BOTTOM}
+      L ${right}, ${magicNumber.CHART_BOTTOM}
+      L ${right}, ${this.chartInfo.maxValue + magicNumber.CHART_BOTTOM}
+      L ${left}, ${this.chartInfo.maxValue + magicNumber.CHART_BOTTOM}
+      L ${left}, ${magicNumber.CHART_BOTTOM}
     `;
     });
   }

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -100,6 +100,7 @@ export default class LineChart extends Component<IListStates, Props> {
         category ? category.color : DELETE_CATEGORY_COLOR
       );
 
+      // 카테고리 클릭 시에만 lineChart 출력
       const lineChartView = document.querySelector(
         '#line-chart-view'
       ) as HTMLDivElement;
@@ -124,6 +125,8 @@ export default class LineChart extends Component<IListStates, Props> {
     const xSection = this.getXSection(dataPoint); // month section
     const pointCircle = this.getPointCircle(dataPoint, color); // point
     const sectionPointGroup = this.makeSectionPointGroup(xSection, pointCircle);
+    const defsElem = this.getDefs(color);
+    svg.appendChild(defsElem);
     svg.appendChild(standYLine);
     svg.appendChild(chart);
     sectionPointGroup.forEach((group) => svg.appendChild(group));
@@ -137,10 +140,10 @@ export default class LineChart extends Component<IListStates, Props> {
     );
     $path.setAttribute('class', 'line-chart-path');
     $path.setAttribute('d', this.getPathAttribute(dataPoint));
-    $path.setAttribute('fill', color);
+    $path.setAttribute('fill', `url('#myGradient')`); //, color);
     $path.setAttribute('stroke', color);
     $path.setAttribute('stroke-width', '4');
-    $path.setAttribute('style', 'transform: scale(1, -1); fill-opacity: 0.3;');
+    $path.setAttribute('style', 'transform: scale(1, -1);');
 
     return $path;
   }
@@ -312,5 +315,23 @@ export default class LineChart extends Component<IListStates, Props> {
     });
 
     return groupList;
+  }
+
+  getDefs(color: string) {
+    const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+    const [r, g, b] = [
+      parseInt(color.substr(1, 2), 16),
+      parseInt(color.substr(3, 2), 16),
+      parseInt(color.substr(5, 2), 16),
+    ];
+    defs.innerHTML = `
+      <linearGradient id="myGradient" gradientTransform="rotate(90)">
+        <stop offset="0%"  stop-color="rgba(${r},${g},${b},0.05)" />
+        <stop offset="40%" stop-color="rgba(${r},${g},${b},0.4)" />
+        <stop offset="70%" stop-color="rgba(${r},${g},${b},0.5)" />
+        <stop offset="100%" stop-color="rgba(${r},${g},${b},0.6)" />
+      </linearGradient>
+    `;
+    return defs;
   }
 }

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -76,7 +76,6 @@ export default class LineChart extends Component<IListStates, Props> {
   }
 
   template() {
-    console.log(this.$state);
     return html`
       <svg
         version="1.1"
@@ -358,7 +357,6 @@ export default class LineChart extends Component<IListStates, Props> {
   getPointCircle(dataPoint: Point[], color: string) {
     const pointList: SVGCircleElement[] = [];
 
-    console.log(dataPoint);
     dataPoint.forEach((data, idx) => {
       const $circle = document.createElementNS(
         'http://www.w3.org/2000/svg',
@@ -416,7 +414,6 @@ export default class LineChart extends Component<IListStates, Props> {
       'http://www.w3.org/2000/svg',
       'path'
     );
-    console.log(point);
 
     const d = `
       M ${point[0]},${magicNumber.CHART_BOTTOM}

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -109,6 +109,15 @@ export default class LineChart extends Component<IListStates, Props> {
       svg.appendChild(standYLine);
       svg.appendChild(chart);
       sectionPointGroup.forEach((group) => svg.appendChild(group));
+
+      const lineChartView = document.querySelector(
+        '#line-chart-view'
+      ) as HTMLDivElement;
+      const prevCategory = lineChartView.dataset.category;
+      lineChartView.dataset.category = selectedCategory;
+
+      if (!prevCategory || prevCategory === selectedCategory)
+        lineChartView.classList.toggle('show');
     }
   }
 

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -68,10 +68,10 @@ export default class LineChart extends Component<IListStates, Props> {
 
     asyncSetState(this.historyModel.getHistoryCard(this.$state.today));
     asyncSetState(this.categoryModel.getUserCategories());
-    asyncSetState(this.historyModel.getAverageByMonth(2021, '식비'));
   }
 
   template() {
+    console.log(this.$state);
     return html`
       <svg
         version="1.1"
@@ -87,10 +87,16 @@ export default class LineChart extends Component<IListStates, Props> {
     `;
   }
 
-  mounted() {
-    const svg = this.$target.querySelector('#line-chart') as SVGElement;
-    if (this.$state?.statList) {
-      const dataPoint = this.getPoints(this.$state?.statList);
+  async mounted() {
+    const { selectedCategory } = this.$state!;
+
+    if (selectedCategory) {
+      const { statList } = await this.historyModel.getAverageByMonth(
+        2021,
+        selectedCategory
+      );
+      const svg = this.$target.querySelector('#line-chart') as SVGElement;
+      const dataPoint = this.getPoints(statList);
 
       const chart = this.getLineChartPath(dataPoint); // line graph
       const standYLine = this.getStandYLine(); // y축 가로선
@@ -280,7 +286,7 @@ export default class LineChart extends Component<IListStates, Props> {
       );
 
       $group.setAttribute('class', 'section-point-group');
-      $group.dataset.id = `${idx}`;
+      $group.dataset.id = `${idx + 1}`;
       $group.appendChild(section);
       $group.appendChild(pointCircle[idx]);
 

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -280,13 +280,15 @@ export default class LineChart extends Component<IListStates, Props> {
     const maxBoundExpense = Math.round(maxExpense / div) * div;
     const intervalExpense = maxBoundExpense / magicNumber.numY;
     const intervalY = this.chartInfo.maxValue / magicNumber.numY;
+    console.log(maxExpense, div, maxBoundExpense, intervalExpense, intervalY);
+
     const standExpenseList = [];
     for (let i = 0; i <= magicNumber.numY; i++) {
       const text = document.createElementNS(
         'http://www.w3.org/2000/svg',
         'text'
       );
-      text.setAttribute('x', `${magicNumber.CHART_LEFT / 2}`);
+      text.setAttribute('x', `${magicNumber.CHART_LEFT - 50}`);
       text.setAttribute('y', `${-(intervalY * i + magicNumber.CHART_BOTTOM)}`);
       text.innerHTML = addComma(`${intervalExpense * i}`);
       standExpenseList.push(text);

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -17,6 +17,7 @@ import HistoryModel from '@/Model/HistoryModel';
 import ChartController from '@/Controller/ChartController';
 import DateModel from '@/Model/DateModel';
 import CategoryModel from '@/Model/CategoryModel';
+import { isHeritageClause } from 'typescript';
 
 interface IListStates extends State {
   today: Today;
@@ -104,10 +105,10 @@ export default class LineChart extends Component<IListStates, Props> {
       const lineChartView = document.querySelector(
         '#line-chart-view'
       ) as HTMLDivElement;
+      const isShowed = lineChartView.className.indexOf('show');
       const prevCategory = lineChartView.dataset.category;
       lineChartView.dataset.category = selectedCategory;
-
-      if (!prevCategory || prevCategory === selectedCategory)
+      if (isShowed === -1 || (isShowed && prevCategory === selectedCategory))
         lineChartView.classList.toggle('show');
     }
   }

--- a/client/src/Components/LineChart/index.ts
+++ b/client/src/Components/LineChart/index.ts
@@ -37,6 +37,7 @@ const magicNumber = {
   CHART_BOTTOM: 100,
   CHART_RIGHT: 100,
   numY: 5,
+  MONTH_NUM: 12,
 };
 
 export default class LineChart extends Component<IListStates, Props> {
@@ -124,7 +125,11 @@ export default class LineChart extends Component<IListStates, Props> {
     const dataPoint = this.getPoints(statList);
 
     const chart = this.getLineChartPath(dataPoint, color); // line graph
-    const { $path: standYLine, $textGroup: textGroup } = this.getStandYLine(); // y축 가로선
+    const {
+      $path: standYLine,
+      $YtextGroup: YGroup,
+      $XtextGroup: XGroup,
+    } = this.getStandYLine(); // y축 가로선
     const xSection = this.getXSection(dataPoint); // month section
     const pointCircle = this.getPointCircle(dataPoint, color); // point
     const expenseText = this.getExpenseText(dataPoint, statList); // 금액
@@ -134,11 +139,9 @@ export default class LineChart extends Component<IListStates, Props> {
       expenseText
     );
     const defsElem = this.getDefs(color);
-    svg.appendChild(defsElem);
-    svg.appendChild(standYLine);
-    svg.appendChild(textGroup);
-    svg.appendChild(chart);
-    sectionPointGroup.forEach((group) => svg.appendChild(group));
+    [standYLine, YGroup, XGroup, chart, ...sectionPointGroup, defsElem].forEach(
+      (elem) => svg.appendChild(elem)
+    );
   }
 
   // 곡선 그래프
@@ -162,7 +165,7 @@ export default class LineChart extends Component<IListStates, Props> {
       magicNumber.WIDTH - (magicNumber.CHART_LEFT + magicNumber.CHART_RIGHT),
       magicNumber.HEIGHT - (magicNumber.CHART_TOP + magicNumber.CHART_BOTTOM),
     ];
-    const intervalX = graphWidth / (data.length - 1);
+    const intervalX = graphWidth / (magicNumber.MONTH_NUM - 1);
     const maxValue = Math.max(...data);
     const max = Math.round(maxValue + maxValue / magicNumber.numY);
 
@@ -235,16 +238,27 @@ export default class LineChart extends Component<IListStates, Props> {
     $path.setAttribute('stroke-width', '2');
     $path.setAttribute('style', 'transform: scale(1, -1)');
 
-    const $textGroup = document.createElementNS(
+    // y축 기준 금액
+    const $YtextGroup = document.createElementNS(
       'http://www.w3.org/2000/svg',
       'g'
     );
-    $textGroup.setAttribute('class', 'line-chart-stand-text');
-    this.getStandText().forEach((text) => {
-      $textGroup.appendChild(text);
+    $YtextGroup.setAttribute('class', 'line-chart-y-stand-text');
+    this.getStandYText().forEach((text) => {
+      $YtextGroup.appendChild(text);
     });
 
-    return { $path, $textGroup };
+    // x축 기준 월
+    const $XtextGroup = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'g'
+    );
+    $XtextGroup.setAttribute('class', 'line-chart-x-stand-text');
+    this.getStandXText().forEach((text) => {
+      $XtextGroup.appendChild(text);
+    });
+
+    return { $path, $YtextGroup, $XtextGroup };
   }
 
   getStandLineAttribute() {
@@ -260,7 +274,7 @@ export default class LineChart extends Component<IListStates, Props> {
       .join('');
   }
 
-  getStandText() {
+  getStandYText() {
     const { maxExpense } = this.chartInfo;
     const div = 10 ** (String(maxExpense).length - 2);
     const maxBoundExpense = Math.round(maxExpense / div) * div;
@@ -278,6 +292,25 @@ export default class LineChart extends Component<IListStates, Props> {
       standExpenseList.push(text);
     }
     return standExpenseList;
+  }
+
+  getStandXText() {
+    const graphWidth =
+      magicNumber.WIDTH - (magicNumber.CHART_LEFT + magicNumber.CHART_RIGHT);
+    const intervalX = graphWidth / (magicNumber.MONTH_NUM - 1);
+
+    const standMonthList = [];
+    for (let i = 0; i < magicNumber.MONTH_NUM; i++) {
+      const text = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'text'
+      );
+      text.setAttribute('x', `${intervalX * i + magicNumber.CHART_LEFT}`);
+      text.setAttribute('y', `${-(magicNumber.CHART_BOTTOM - 50)}`);
+      text.innerHTML = `${i + 1}월`;
+      standMonthList.push(text);
+    }
+    return standMonthList;
   }
 
   // 마우스 hover시 나타나는 section

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -7,7 +7,6 @@
   }
 
   .month-point {
-    fill: $primary1;
     opacity: 0;
   }
 
@@ -17,7 +16,6 @@
       opacity: 0.15;
     }
     .month-point {
-      fill: $primary1;
       opacity: 1;
     }
   }

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -16,6 +16,14 @@
     font-size: 2.7rem;
   }
 
+  &.line-chart-today-line {
+    .month-section,
+    .month-point,
+    .point-text {
+      opacity: 1;
+    }
+  }
+
   &:hover {
     .month-section {
       fill: $grey1;

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -42,8 +42,14 @@
   animation: draw 0.8s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.line-chart-stand-text {
+.line-chart-y-stand-text {
   @include body-large;
   font-size: 2.5rem;
   text-anchor: end;
+}
+
+.line-chart-x-stand-text {
+  @include body-large;
+  font-size: 2.5rem;
+  text-anchor: middle;
 }

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -41,3 +41,8 @@
 .line-chart-path {
   animation: draw 0.8s cubic-bezier(0.16, 1, 0.3, 1);
 }
+
+.line-chart-stand-text {
+  @include body-large;
+  font-size: 2.7rem;
+}

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -9,6 +9,12 @@
   .month-point {
     opacity: 0;
   }
+  .point-text {
+    @include bold-large;
+    opacity: 0;
+    text-anchor: middle;
+    font-size: 2.7rem;
+  }
 
   &:hover {
     .month-section {
@@ -16,6 +22,9 @@
       opacity: 0.1;
     }
     .month-point {
+      opacity: 1;
+    }
+    .point-text {
       opacity: 1;
     }
   }
@@ -30,5 +39,5 @@
   }
 }
 .line-chart-path {
-  animation: draw 0.6s cubic-bezier(0, 0.55, 0.45, 1);
+  animation: draw 0.8s cubic-bezier(0.16, 1, 0.3, 1);
 }

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -4,8 +4,8 @@
   .month-section {
     fill: rgba(0, 0, 0, 0);
     stroke: none;
+    opacity: 0;
   }
-
   .month-point {
     opacity: 0;
   }
@@ -13,10 +13,22 @@
   &:hover {
     .month-section {
       fill: $grey1;
-      opacity: 0.15;
+      opacity: 0.1;
     }
     .month-point {
       opacity: 1;
     }
   }
+}
+
+@keyframes draw {
+  to {
+    transform: scaleY(-1);
+  }
+  from {
+    transform: scaleY(0);
+  }
+}
+.line-chart-path {
+  animation: draw 0.6s cubic-bezier(0, 0.55, 0.45, 1);
 }

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -1,1 +1,24 @@
 @import '@/scss/theme';
+
+.section-point-group {
+  .month-section {
+    fill: rgba(0, 0, 0, 0);
+    stroke: none;
+  }
+
+  .month-point {
+    fill: $primary1;
+    opacity: 0;
+  }
+
+  &:hover {
+    .month-section {
+      fill: $grey1;
+      opacity: 0.15;
+    }
+    .month-point {
+      fill: $primary1;
+      opacity: 1;
+    }
+  }
+}

--- a/client/src/Components/LineChart/styles.scss
+++ b/client/src/Components/LineChart/styles.scss
@@ -44,5 +44,6 @@
 
 .line-chart-stand-text {
   @include body-large;
-  font-size: 2.7rem;
+  font-size: 2.5rem;
+  text-anchor: end;
 }

--- a/client/src/Model/HistoryModel.ts
+++ b/client/src/Model/HistoryModel.ts
@@ -1,5 +1,6 @@
 import {
   deleteHistory,
+  getAverageByMonth,
   getHistories,
   insertHistory,
   updateHistory,
@@ -28,6 +29,7 @@ class HistoryModel extends Observable {
   selectedType: number;
   selectedCategory: string;
   selectedHistoryForCategory: IHistory[];
+  statList?: number[];
 
   constructor() {
     super();
@@ -101,6 +103,12 @@ class HistoryModel extends Observable {
     console.log(history);
 
     return this.notify(this.key, { historyCards: this.historyCards });
+  }
+
+  async getAverageByMonth(year: number, category: string) {
+    const res = await getAverageByMonth(year, category);
+
+    return this.notify(this.key, { statList: res.data.result });
   }
 
   initHistoryForToday() {

--- a/client/src/Model/HistoryModel.ts
+++ b/client/src/Model/HistoryModel.ts
@@ -108,7 +108,7 @@ class HistoryModel extends Observable {
   async getAverageByMonth(year: number, category: string) {
     const res = await getAverageByMonth(year, category);
 
-    return this.notify(this.key, { statList: res.data.result });
+    return { statList: res.data.result };
   }
 
   initHistoryForToday() {

--- a/client/src/View/ChartsView/index.ts
+++ b/client/src/View/ChartsView/index.ts
@@ -17,7 +17,7 @@ export default class ChartsView extends Component<State, Props> {
               <div class="history-category-list-wrapper"></div>
             </atricle>
           </div>
-          <div class="chart-background">
+          <div class="chart-background" id="line-chart-view">
             <article class="chart-view">
               <div class="line-chart-view"></div>
             </article>

--- a/client/src/View/ChartsView/styles.scss
+++ b/client/src/View/ChartsView/styles.scss
@@ -37,6 +37,10 @@
           width: 50%;
           height: 100%;
         }
+
+        .line-chart-view {
+          width: 100%;
+        }
       }
     }
 

--- a/client/src/View/ChartsView/styles.scss
+++ b/client/src/View/ChartsView/styles.scss
@@ -11,7 +11,7 @@
 
     .chart-background {
       width: 100%;
-      min-height: 60rem;
+      // min-height: 60rem;
       padding: 3.5rem 5rem;
       box-sizing: border-box;
       display: flex;
@@ -21,6 +21,7 @@
       box-shadow: 0 0.4rem 0.4rem rgba(0, 0, 0, 0.1),
         0 0.4rem 2rem rgba(0, 0, 0, 0.1);
       border-radius: 1rem;
+      margin-bottom: 5rem;
 
       .chart-view {
         display: flex;
@@ -43,9 +44,15 @@
         }
       }
     }
+  }
+}
 
-    .chart-background + .chart-background {
-      margin-top: 5rem;
-    }
+#line-chart-view {
+  display: none;
+  height: 0;
+
+  &.show {
+    display: flex;
+    height: fit-content;
   }
 }

--- a/client/src/api/history.ts
+++ b/client/src/api/history.ts
@@ -38,6 +38,6 @@ export const deleteHistory = async (historyId: number) =>
   });
 
 export const getAverageByMonth = async (year: number, category: string) =>
-  axios.get(`${APIENDPOINT}/stat/${year}/${category}`, {
+  axios.get(`${APIENDPOINT}/stat/${year}/${category.replace('/', '%2F')}`, {
     withCredentials: true,
   });

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -83,6 +83,7 @@ export interface HistoryType {
   income?: boolean;
 }
 export interface HistoryModelType extends Model {
+  getAverageByMonth(arg0: number, arg1: string): Promise<curType>;
   key: string;
   historyCards: IHistory[];
   historyType: HistoryType;
@@ -94,6 +95,7 @@ export interface HistoryModelType extends Model {
   addHistory: (history: IHistory) => Promise<curType>;
   updateHistory: (history: IHistory) => Promise<curType>;
   deleteHistoryCard: (historyId: number) => Promise<curType>;
+  getAverageByMonth: (year: number, category: string) => Promise<curType>;
   toggleType: (nextType: typeString) => Promise<curType>;
   toggleSelectedType: (type: number) => Promise<curType>;
   getTodaysHistoryCard: (today: Today) => Promise<curType>;

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -83,7 +83,6 @@ export interface HistoryType {
   income?: boolean;
 }
 export interface HistoryModelType extends Model {
-  getAverageByMonth(arg0: number, arg1: string): Promise<curType>;
   key: string;
   historyCards: IHistory[];
   historyType: HistoryType;
@@ -95,7 +94,7 @@ export interface HistoryModelType extends Model {
   addHistory: (history: IHistory) => Promise<curType>;
   updateHistory: (history: IHistory) => Promise<curType>;
   deleteHistoryCard: (historyId: number) => Promise<curType>;
-  getAverageByMonth: (year: number, category: string) => Promise<curType>;
+  getAverageByMonth: (year: number, category: string) => Promise<any>;
   toggleType: (nextType: typeString) => Promise<curType>;
   toggleSelectedType: (type: number) => Promise<curType>;
   getTodaysHistoryCard: (today: Today) => Promise<curType>;

--- a/server/api/routes/history.ts
+++ b/server/api/routes/history.ts
@@ -10,7 +10,7 @@ export default (app: Router) => {
   router.get(
     `/stat/:year/:categoryType`,
     authMiddleware,
-    historyController.getAverageByMonth
+    historyController.getSumByMonth
   );
   router.get(`/`, authMiddleware, historyController.selectHistory);
   router.post(`/`, authMiddleware, historyController.insertHistory);

--- a/server/controllers/history.controller.ts
+++ b/server/controllers/history.controller.ts
@@ -69,11 +69,11 @@ class HistoryController {
     }
   }
 
-  async getAverageByMonth(req: Request, res: Response, next: NextFunction) {
+  async getSumByMonth(req: Request, res: Response, next: NextFunction) {
     try {
       const userId = getPayload(req);
       const { categoryType, year } = req.params;
-      const result = await HistoryServices.getAverageByMonth(
+      const result = await HistoryServices.getSumByMonth(
         userId,
         categoryType,
         +year

--- a/server/repositories/history.repository.ts
+++ b/server/repositories/history.repository.ts
@@ -43,15 +43,15 @@ where userId=1 and date_format(createdAt, '%Y')='2021' and category='식비'
 group by month
    */
 
-  async getAverageByMonth(
+  async getSumByMonth(
     id: number,
     categoryType: string,
     year: number
-  ): Promise<{ month: string; average: string }[]> {
+  ): Promise<{ month: string; sum: string }[]> {
     const result = await this.createQueryBuilder()
       .select([
         `date_format(createdAt, '%m') AS month`,
-        `round(avg(price)) AS average`,
+        `round(sum(price)) AS sum`,
       ])
       .where('userId=:id', { id })
       .andWhere('category=:categoryType', { categoryType })

--- a/server/services/history.services.ts
+++ b/server/services/history.services.ts
@@ -72,7 +72,14 @@ export default class HistoryService {
         HistoryRepository
       ).getAverageByMonth(id, categoryType, year);
 
-      return result.map((res) => Number(res.average));
+      const averageForMonth = [];
+      for (let i = 0, j = 0; i < 12; i++) {
+        if (j < result.length && Number(result[j].month) === i) {
+          averageForMonth.push(Number(result[j++].average));
+        } else averageForMonth.push(0);
+      }
+
+      return averageForMonth;
     } catch (error) {
       throw new Error('[history 쿼리 에러] ' + error);
     }

--- a/server/services/history.services.ts
+++ b/server/services/history.services.ts
@@ -66,15 +66,13 @@ export default class HistoryService {
     id: number,
     categoryType: string,
     year: number
-  ): Promise<{ month: number; average: number }[]> {
+  ): Promise<number[]> {
     try {
       const result = await getCustomRepository(
         HistoryRepository
       ).getAverageByMonth(id, categoryType, year);
 
-      return result.map((res) => {
-        return { month: Number(res.month), average: Number(res.average) };
-      });
+      return result.map((res) => Number(res.average));
     } catch (error) {
       throw new Error('[history 쿼리 에러] ' + error);
     }

--- a/server/services/history.services.ts
+++ b/server/services/history.services.ts
@@ -62,24 +62,26 @@ export default class HistoryService {
     }
   }
 
-  async getAverageByMonth(
+  async getSumByMonth(
     id: number,
     categoryType: string,
     year: number
   ): Promise<number[]> {
     try {
-      const result = await getCustomRepository(
-        HistoryRepository
-      ).getAverageByMonth(id, categoryType, year);
+      const result = await getCustomRepository(HistoryRepository).getSumByMonth(
+        id,
+        categoryType,
+        year
+      );
 
-      const averageForMonth = [];
+      const sumForMonth = [];
       for (let i = 0, j = 0; i < 12; i++) {
         if (j < result.length && Number(result[j].month) === i) {
-          averageForMonth.push(Number(result[j++].average));
-        } else averageForMonth.push(0);
+          sumForMonth.push(Number(result[j++].sum));
+        } else sumForMonth.push(0);
       }
 
-      return averageForMonth;
+      return sumForMonth;
     } catch (error) {
       throw new Error('[history 쿼리 에러] ' + error);
     }

--- a/server/services/history.services.ts
+++ b/server/services/history.services.ts
@@ -76,7 +76,7 @@ export default class HistoryService {
 
       const sumForMonth = [];
       for (let i = 0, j = 0; i < 12; i++) {
-        if (j < result.length && Number(result[j].month) === i) {
+        if (j < result.length && Number(result[j].month) - 1 === i) {
           sumForMonth.push(Number(result[j++].sum));
         } else sumForMonth.push(0);
       }

--- a/server/services/history.services.ts
+++ b/server/services/history.services.ts
@@ -66,14 +66,14 @@ export default class HistoryService {
     id: number,
     categoryType: string,
     year: number
-  ): Promise<{ month: number; average: string }[]> {
+  ): Promise<{ month: number; average: number }[]> {
     try {
       const result = await getCustomRepository(
         HistoryRepository
       ).getAverageByMonth(id, categoryType, year);
 
       return result.map((res) => {
-        return { month: Number(res.month), average: res.average };
+        return { month: Number(res.month), average: Number(res.average) };
       });
     } catch (error) {
       throw new Error('[history 쿼리 에러] ' + error);


### PR DESCRIPTION
* it closes #7 


1. DB에서 month를 가져올 때 1월이 index 0인 것을 간과해서 이것 때문에 생긴 버그 수정했습니다.
2. 라인 차트 마크업하였습니다.
3. API 연동해서 값을 가져와 svg로 그래프를 그립니다.
    - 마우스 오버하면 해당 월에 background와 금액이 표시됩니다.
    - 현재 월에 해당하는 그래프의 point는 hover하지 않아도 표시됩니다.